### PR TITLE
Feature/issue conversation logic

### DIFF
--- a/Goose.API/Authorization/AuthorizationUtil.cs
+++ b/Goose.API/Authorization/AuthorizationUtil.cs
@@ -27,5 +27,39 @@ namespace Goose.API.Authorization
                 throw new HttpStatusException(StatusCodes.Status403Forbidden, "You are missing one or more requirements, in order to process this request.");
             }
         }
+
+        public static void ThrowErrorIfAllFailed(this AuthorizationResult authorizationResult, Dictionary<IAuthorizationRequirement, string> errorMap)
+        {
+            if (authorizationResult.Succeeded)
+            {
+                // All requirements succeded, no need to check every single one
+                return;
+            }
+
+            if (authorizationResult.Failure.FailedRequirements.Count() < errorMap.Count)
+            {
+                // Not all Requirements have failed
+                return;
+            }
+
+            var errorMsg = "";
+
+            foreach(var failedRequirement in authorizationResult.Failure.FailedRequirements)
+            {
+                if (errorMap.TryGetValue(failedRequirement, out string errorMessage))
+                {
+                    errorMsg += errorMsg;
+                }
+                else
+                {
+                    // Fallback msg
+                    errorMsg = "You are missing a requirements, in order to process this request.";
+                }
+
+                errorMsg += '\n';
+            }
+
+            throw new HttpStatusException(StatusCodes.Status403Forbidden, errorMsg);
+        }
     }
 }

--- a/Goose.API/Authorization/AuthorizationUtil.cs
+++ b/Goose.API/Authorization/AuthorizationUtil.cs
@@ -1,0 +1,31 @@
+﻿using Goose.API.Authorization.Requirements;
+using Goose.API.Utils.Exceptions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Goose.API.Authorization
+{
+    public static class AuthorizationUtils
+    {
+        public static void ThrowErrorForFailedRequirements(this AuthorizationResult authorizationResult, Dictionary<IAuthorizationRequirement, string> errorMap)
+        {
+            // if result is successfull or do not serve a failiture, we do not have to throws errors.
+            if (authorizationResult.Succeeded || authorizationResult.Failure is null)
+                return;
+
+            // for each failied req. throw an error if served, else throw generic error. 
+            foreach (var failedRequirement in authorizationResult.Failure.FailedRequirements)
+            {
+                if (errorMap.TryGetValue(failedRequirement, out string errorMessage))
+                    throw new HttpStatusException(StatusCodes.Status403Forbidden, errorMessage);
+
+                // fallback error message.
+                throw new HttpStatusException(StatusCodes.Status403Forbidden, "You are missing one or more requirements, in order to process this request.");
+            }
+        }
+    }
+}

--- a/Goose.API/Controllers/ConversationController.cs
+++ b/Goose.API/Controllers/ConversationController.cs
@@ -2,7 +2,7 @@
 using Goose.API.Services;
 using Goose.API.Utils.Exceptions;
 using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;

--- a/Goose.API/Controllers/ConversationController.cs
+++ b/Goose.API/Controllers/ConversationController.cs
@@ -2,7 +2,7 @@
 using Goose.API.Services;
 using Goose.API.Utils.Exceptions;
 using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.tickets;
+using Goose.Domain.Models.Tickets;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;

--- a/Goose.API/Controllers/ConversationController.cs
+++ b/Goose.API/Controllers/ConversationController.cs
@@ -1,6 +1,8 @@
 ﻿
 using Goose.API.Services;
-using Goose.Domain.DTOs.Tickets;
+using Goose.API.Utils.Exceptions;
+using Goose.Domain.DTOs.tickets;
+using Goose.Domain.Models.tickets;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
@@ -44,6 +46,11 @@ namespace Goose.API.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromRoute] string issueId, [FromBody] IssueConversationDTO conversationItem)
         {
+            if (conversationItem.Type != IssueConversation.MessageType)
+            {
+                throw new HttpStatusException(400, $"Invalid conversation type, only \"{IssueConversation.MessageType}\" allowed");
+            }
+
             var newIssueConversation = await _issueConversationService.CreateNewIssueConversationAsync(issueId, conversationItem);
             return CreatedAtAction(nameof(GetById), new { issueId, id = newIssueConversation.Id }, newIssueConversation);
         }
@@ -54,6 +61,11 @@ namespace Goose.API.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] string issueId, [FromRoute] string id, [FromBody] IssueConversationDTO conversationItem)
         {
+            if (conversationItem.Type != IssueConversation.MessageType)
+            {
+                throw new HttpStatusException(400, $"Invalid conversation type, only \"{IssueConversation.MessageType}\" allowed");
+            }
+
             await _issueConversationService.CreateOrReplaceConversationItemAsync(issueId, id, conversationItem);
             return NoContent();
         }

--- a/Goose.API/Controllers/ConversationController.cs
+++ b/Goose.API/Controllers/ConversationController.cs
@@ -1,7 +1,7 @@
 ﻿
 using Goose.API.Services;
 using Goose.API.Utils.Exceptions;
-using Goose.Domain.DTOs.tickets;
+using Goose.Domain.DTOs.Issues;
 using Goose.Domain.Models.tickets;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/Goose.API/Controllers/issuesControllers/IssueParentController.cs
+++ b/Goose.API/Controllers/issuesControllers/IssueParentController.cs
@@ -5,6 +5,7 @@ using Goose.API.Utils;
 using Goose.Domain.DTOs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Bson;
 
 namespace Goose.API.Controllers.IssuesControllers
 {
@@ -23,9 +24,9 @@ namespace Goose.API.Controllers.IssuesControllers
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<IList<UserDTO>>> Get([FromRoute] string issueId)
+    public async Task<ActionResult<IList<UserDTO>>> Get([FromRoute] ObjectId issueId)
     {
-        var issue = await _issueService.GetParent(issueId.ToObjectId());
+        var issue = await _issueService.GetParent(issueId);
         if (issue == null) return NotFound();
         return Ok(issue);
     }
@@ -33,18 +34,18 @@ namespace Goose.API.Controllers.IssuesControllers
     [HttpPut("{parentId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult> Put([FromRoute] string issueId, [FromRoute] string parentId)
+    public async Task<ActionResult> Put([FromRoute] ObjectId issueId, [FromRoute] ObjectId parentId)
     {
-        await _issueService.SetParent(issueId.ToObjectId(), parentId.ToObjectId());
+        await _issueService.SetParent(issueId, parentId);
         return NoContent();
     }
 
     [HttpDelete]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult> Delete([FromRoute] string issueId)
+    public async Task<ActionResult> Delete([FromRoute] ObjectId issueId)
     {
-        await _issueService.RemoveParent(issueId.ToObjectId());
+        await _issueService.RemoveParent(issueId);
         return NoContent();
     }
     }

--- a/Goose.API/Controllers/issuesControllers/IssueRequirementsController.cs
+++ b/Goose.API/Controllers/issuesControllers/IssueRequirementsController.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Goose.API.Services.Issues;
 using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Goose.API.Utils;
 using Microsoft.AspNetCore.Mvc;
 

--- a/Goose.API/Controllers/issuesControllers/IssueSummaryController.cs
+++ b/Goose.API/Controllers/issuesControllers/IssueSummaryController.cs
@@ -1,5 +1,5 @@
 ﻿using Goose.API.Services.issues;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;

--- a/Goose.API/Controllers/issuesControllers/IssuesController.cs
+++ b/Goose.API/Controllers/issuesControllers/IssuesController.cs
@@ -22,7 +22,7 @@ namespace Goose.API.Controllers.IssuesControllers
             _issueDetailedService = issueDetailedService;
         }
 
-        //api/issues/
+        //api/projects/{projectId}/issues/
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -37,7 +37,7 @@ namespace Goose.API.Controllers.IssuesControllers
             return Ok(await res);
         }
 
-        //api/issues/{id}
+        //api/projects/{projectId}/issues/{id}
         [HttpGet("{id}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -52,7 +52,7 @@ namespace Goose.API.Controllers.IssuesControllers
             return res == null ? NotFound() : Ok(res);
         }
 
-        //api/issues
+        //api/projects/{projectId}/issues
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -66,7 +66,7 @@ namespace Goose.API.Controllers.IssuesControllers
             return CreatedAtAction(nameof(Get), new {projectId, id = res.Id}, res);
         }
 
-        //api/issues/{id}
+        //api/projects/{projectId}/issues/{id}
         [HttpPut("{id}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -76,7 +76,7 @@ namespace Goose.API.Controllers.IssuesControllers
             return NoContent();
         }
 
-        //api/issues/{id}  
+        //api/projects/{projectId}/issues/{id}  
         [HttpDelete("{id}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/Goose.API/Controllers/issuesControllers/IssuesController.cs
+++ b/Goose.API/Controllers/issuesControllers/IssuesController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Goose.API.Services.Issues;
 using Goose.Domain.DTOs.Issues;
 using Goose.API.Utils;
+using Goose.Domain.DTOs.Issues;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 

--- a/Goose.API/Controllers/issuesControllers/IssuesController.cs
+++ b/Goose.API/Controllers/issuesControllers/IssuesController.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Goose.API.Services.Issues;
 using Goose.Domain.DTOs.Issues;
 using Goose.API.Utils;
-using Goose.Domain.DTOs.Issues;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 

--- a/Goose.API/Controllers/issuesControllers/IssuesPredecessorController.cs
+++ b/Goose.API/Controllers/issuesControllers/IssuesPredecessorController.cs
@@ -4,6 +4,7 @@ using Goose.API.Services.Issues;
 using Goose.API.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Bson;
 
 namespace Goose.API.Controllers.IssuesControllers
 {
@@ -21,22 +22,18 @@ namespace Goose.API.Controllers.IssuesControllers
         [HttpPut("{predecessorId}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> SetPredecessor([FromRoute] string projectId,
-            [FromRoute] string issueId, [FromRoute] string predecessorId)
+        public async Task<ActionResult> SetPredecessor([FromRoute] ObjectId issueId, [FromRoute] ObjectId predecessorId)
         {
-            await _issueService.SetPredecessor(projectId.ToObjectId(), issueId.ToObjectId(),
-                predecessorId.ToObjectId());
+            await _issueService.SetPredecessor(issueId, predecessorId);
             return NoContent();
         }
 
         [HttpDelete("{predecessorId}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> RemovePredecessor([FromRoute] string projectId,
-            [FromRoute] string issueId, [FromRoute] string predecessorId)
+        public async Task<ActionResult> RemovePredecessor([FromRoute] ObjectId issueId, [FromRoute] ObjectId predecessorId)
         {
-            await _issueService.RemovePredecessor(projectId.ToObjectId(), issueId.ToObjectId(),
-                predecessorId.ToObjectId());
+            await _issueService.RemovePredecessor(issueId, predecessorId);
             return NoContent();
         }
     }

--- a/Goose.API/Goose.API.csproj
+++ b/Goose.API/Goose.API.csproj
@@ -9,6 +9,10 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;AUTHORISATION</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />

--- a/Goose.API/Goose.API.csproj
+++ b/Goose.API/Goose.API.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;AUTHORISATION</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 	
   <ItemGroup>

--- a/Goose.API/Goose.API.csproj
+++ b/Goose.API/Goose.API.csproj
@@ -12,11 +12,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;AUTHORISATION</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;AUTHORISATION</DefineConstants>
-  </PropertyGroup>
-
+	
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />

--- a/Goose.API/Repositories/IssueRepository.cs
+++ b/Goose.API/Repositories/IssueRepository.cs
@@ -2,7 +2,7 @@
 using Goose.API.Utils.Validators;
 using Goose.Data.Context;
 using Goose.Data.Repository;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Http;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Goose.API/Services/IssueConversationService.cs
+++ b/Goose.API/Services/IssueConversationService.cs
@@ -137,7 +137,7 @@ namespace Goose.API.Services
             IssueConversation newConversation = new IssueConversation()
             {
                 Id = ObjectId.GenerateNewId(),
-                CreatorUserId = conversationItem.Creator.Id,
+                CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Data = conversationItem.Data,
                 Requirements = new List<string>(),
                 Type = conversationItem.Type
@@ -196,7 +196,7 @@ namespace Goose.API.Services
 
             // validate requirements with the appropriate handlers.
             var authorizationResult = await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, project, requirementsWithErrors.Keys);
-            authorizationResult.ThrowErrorForFailedRequirements(requirementsWithErrors);
+            authorizationResult.ThrowErrorIfAllFailed(requirementsWithErrors);
             #endif
         }
 
@@ -215,7 +215,7 @@ namespace Goose.API.Services
 
             // validate requirements with the appropriate handlers.
             var authorizationResult = await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, project, requirementsWithErrors.Keys);
-            authorizationResult.ThrowErrorForFailedRequirements(requirementsWithErrors);
+            authorizationResult.ThrowErrorIfAllFailed(requirementsWithErrors);
             #endif
         }
     }

--- a/Goose.API/Services/IssueConversationService.cs
+++ b/Goose.API/Services/IssueConversationService.cs
@@ -1,9 +1,9 @@
 ﻿using Goose.API.Repositories;
-using Goose.API.Services.issues;
+using Goose.API.Services.Issues;
 using Goose.API.Utils.Exceptions;
 using Goose.API.Utils.Validators;
 using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.tickets;
+using Goose.Domain.Models.Tickets;
 using Microsoft.AspNetCore.Http;
 using MongoDB.Bson;
 using System.Collections.Generic;
@@ -59,7 +59,7 @@ namespace Goose.API.Services
 
         private async Task<IssueConversationDTO> MapIssueConversationDTOAsync(ObjectId issueId, IssueConversation ic)
         {
-            var creator = await _userService.GetUser(ic.CreatorUserId);
+            var creator = await _userService.GetUser(ic.CreatorUserId.Value);
 
             var requirements = await Task.WhenAll(ic.RequirementIds.Select(async reqOid => await _issueRepository.GetRequirementByIdAsync(issueId, reqOid)).ToList());
 

--- a/Goose.API/Services/IssueConversationService.cs
+++ b/Goose.API/Services/IssueConversationService.cs
@@ -2,8 +2,8 @@
 using Goose.API.Services.issues;
 using Goose.API.Utils.Exceptions;
 using Goose.API.Utils.Validators;
-using Goose.Domain.DTOs.Tickets;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.DTOs.Issues;
+using Goose.Domain.Models.tickets;
 using Microsoft.AspNetCore.Http;
 using MongoDB.Bson;
 using System.Collections.Generic;

--- a/Goose.API/Services/IssueConversationService.cs
+++ b/Goose.API/Services/IssueConversationService.cs
@@ -3,7 +3,7 @@ using Goose.API.Services.Issues;
 using Goose.API.Utils.Exceptions;
 using Goose.API.Utils.Validators;
 using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Http;
 using MongoDB.Bson;
 using System.Collections.Generic;

--- a/Goose.API/Services/IssueConversationService.cs
+++ b/Goose.API/Services/IssueConversationService.cs
@@ -1,4 +1,5 @@
 ﻿using Goose.API.Repositories;
+using Goose.API.Services.issues;
 using Goose.API.Utils.Exceptions;
 using Goose.API.Utils.Validators;
 using Goose.Domain.DTOs.Tickets;
@@ -22,11 +23,13 @@ namespace Goose.API.Services
     public class IssueConversationService : IIssueConversationService
     {
         private readonly IIssueRepository _issueRepository;
+        private readonly IIssueService _issueService;
         private readonly IUserService _userService;
 
-        public IssueConversationService(IIssueRepository issueRepository, IUserService userService)
+        public IssueConversationService(IIssueRepository issueRepository, IIssueService issueService, IUserService userService)
         {
             _issueRepository = issueRepository;
+            _issueService = issueService;
             _userService = userService;
         }
 
@@ -98,6 +101,9 @@ namespace Goose.API.Services
         public async Task<IssueConversationDTO> CreateNewIssueConversationAsync(string issueId, IssueConversationDTO conversationItem)
         {
             var issue = await _issueRepository.GetIssueByIdAsync(issueId);
+
+            await _issueService.AssertNotArchived(issue);
+
             var conversationItems = issue.ConversationItems;
 
             // if ConversationItems are null = empty, create a new list, which will gets appended.

--- a/Goose.API/Services/ProjectService.cs
+++ b/Goose.API/Services/ProjectService.cs
@@ -7,7 +7,6 @@ using Goose.Domain.Models.Projects;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Goose.Domain.Models;
-using Goose.Domain.Models.Projects;
 using MongoDB.Bson;
 using System.Collections.Generic;
 using System.Linq;

--- a/Goose.API/Services/ProjectUserService.cs
+++ b/Goose.API/Services/ProjectUserService.cs
@@ -136,7 +136,7 @@ namespace Goose.API.Services
 
                 if (existingProjectLeader.Any())
                 {
-                    throw new HttpStatusException(403, "Cannot make to users a project Leader");
+                    throw new HttpStatusException(403, "Cannot make two users a project Leader");
                 }
             }
 

--- a/Goose.API/Services/issues/IssueDetailedService.cs
+++ b/Goose.API/Services/issues/IssueDetailedService.cs
@@ -9,6 +9,11 @@ using Goose.Domain.Models.Tickets;
 using Goose.API.Utils.Exceptions;
 using Goose.API.Utils.Validators;
 using Microsoft.AspNetCore.Http;
+using Goose.Domain.DTOs.Issues;
+using Goose.Domain.DTOs.tickets;
+using Goose.Domain.Models.identity;
+using Goose.Domain.Models.tickets;
+using Microsoft.AspNetCore.Http.Features;
 using MongoDB.Bson;
 
 namespace Goose.API.Services.Issues

--- a/Goose.API/Services/issues/IssueDetailedService.cs
+++ b/Goose.API/Services/issues/IssueDetailedService.cs
@@ -5,14 +5,11 @@ using Goose.API.Repositories;
 using Goose.API.Services.Issues;
 using Goose.Domain.DTOs;
 using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Goose.API.Utils.Exceptions;
 using Goose.API.Utils.Validators;
 using Microsoft.AspNetCore.Http;
-using Goose.Domain.DTOs.Issues;
-using Goose.Domain.DTOs.tickets;
-using Goose.Domain.Models.identity;
-using Goose.Domain.Models.tickets;
+using Goose.Domain.Models.Identity;
 using Microsoft.AspNetCore.Http.Features;
 using MongoDB.Bson;
 

--- a/Goose.API/Services/issues/IssuePredecessorService.cs
+++ b/Goose.API/Services/issues/IssuePredecessorService.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Goose.API.Repositories;
+using Goose.API.Utils.Authentication;
 using Goose.Domain.Models.Issues;
+using Microsoft.AspNetCore.Http;
 using MongoDB.Bson;
 
 namespace Goose.API.Services.Issues
@@ -19,9 +21,12 @@ namespace Goose.API.Services.Issues
         //TODO wie bekommt man am besten alle issues in einem vorgänger baum? phil fragen?
         private readonly IIssueRepository _issueRepo;
 
-        public IssuePredecessorService(IIssueRepository issueRepo)
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public IssuePredecessorService(IIssueRepository issueRepo, IHttpContextAccessor httpContextAccessor)
         {
             _issueRepo = issueRepo;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         public async Task SetPredecessor(ObjectId projectId, ObjectId successorId, ObjectId predecessorId)
@@ -36,7 +41,7 @@ namespace Goose.API.Services.Issues
             successor.ConversationItems.Add(new IssueConversation()
             {
                 Id = ObjectId.GenerateNewId(),
-                CreatorUserId = null,
+                CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.PredecessorAddedType,
                 Data = $"{predecessorId}",
             });
@@ -54,7 +59,7 @@ namespace Goose.API.Services.Issues
                 successor.ConversationItems.Add(new IssueConversation()
                 {
                     Id = ObjectId.GenerateNewId(),
-                    CreatorUserId = null,
+                    CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                     Type = IssueConversation.PredecessorRemovedType,
                     Data = $"{predecessorId}",
                 });

--- a/Goose.API/Services/issues/IssuePredecessorService.cs
+++ b/Goose.API/Services/issues/IssuePredecessorService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Goose.API.Repositories;
 using Goose.API.Utils.Authentication;
 using Goose.API.Utils.Exceptions;
+using Goose.Domain.DTOs.Issues;
 using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Http;
 using MongoDB.Bson;
@@ -13,8 +14,8 @@ namespace Goose.API.Services.Issues
     public interface IIssuePredecessorService
     {
         public Task<IList<IssueDTO>> GetAll(ObjectId issueId);
-        public Task SetPredecessor(ObjectId projectId, ObjectId successorId, ObjectId predecessorId);
-        public Task RemovePredecessor(ObjectId projectId, ObjectId successorId, ObjectId predecessorId);
+        public Task SetPredecessor(ObjectId successorId, ObjectId predecessorId);
+        public Task RemovePredecessor(ObjectId successorId, ObjectId predecessorId);
     }
 
     public class IssuePredecessorService : IIssuePredecessorService

--- a/Goose.API/Services/issues/IssuePredecessorService.cs
+++ b/Goose.API/Services/issues/IssuePredecessorService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Goose.API.Repositories;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using MongoDB.Bson;
 
 namespace Goose.API.Services.Issues

--- a/Goose.API/Services/issues/IssuePredecessorService.cs
+++ b/Goose.API/Services/issues/IssuePredecessorService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Goose.API.Repositories;
-using Goose.Domain.Models.tickets;
+using Goose.Domain.Models.Tickets;
 using MongoDB.Bson;
 
 namespace Goose.API.Services.Issues

--- a/Goose.API/Services/issues/IssueRequirementService.cs
+++ b/Goose.API/Services/issues/IssueRequirementService.cs
@@ -6,7 +6,7 @@ using AutoMapper.Mappers;
 using Goose.API.Repositories;
 using Goose.API.Utils.Exceptions;
 using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using MongoDB.Bson;
 
 namespace Goose.API.Services.Issues

--- a/Goose.API/Services/issues/IssueService.cs
+++ b/Goose.API/Services/issues/IssueService.cs
@@ -191,12 +191,18 @@ namespace Goose.API.Services.Issues
         public async Task SetParent(ObjectId issueId, ObjectId parentId)
         {
             var issue = await _issueRepo.GetAsync(issueId);
+            var parent = await _issueRepo.GetAsync(parentId);
+
+            if (issue.ProjectId != parent.ProjectId)
+            {
+                throw new HttpStatusException(StatusCodes.Status400BadRequest, "Issues müssen im selben Projekt sein");
+            }
+
             issue.ParentIssueId = parentId;
             await _issueRepo.UpdateAsync(issue);
 
             // ConversationItem im Oberticket hinzufügen
-            var parent = await _issueRepo.GetAsync(parentId);
-            issue.ConversationItems.Add(new IssueConversation()
+            parent.ConversationItems.Add(new IssueConversation()
             {
                 Id = ObjectId.GenerateNewId(),
                 CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
@@ -217,7 +223,7 @@ namespace Goose.API.Services.Issues
             {
                 // ConversationItem im Oberticket hinzufügen
                 var parent = await _issueRepo.GetAsync(parentId);
-                issue.ConversationItems.Add(new IssueConversation()
+                parent.ConversationItems.Add(new IssueConversation()
                 {
                     Id = ObjectId.GenerateNewId(),
                     CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),

--- a/Goose.API/Services/issues/IssueService.cs
+++ b/Goose.API/Services/issues/IssueService.cs
@@ -267,22 +267,5 @@ namespace Goose.API.Services.Issues
                 throw new HttpStatusException(403, "Issue is archived.");
             }
         }
-
-        /// <summary>
-        /// This method checks that the issue is not archived. If it is, it throws a
-        /// HttpStatusException with 403 - Forbidden
-        /// </summary>
-        /// <param name="issue"></param>
-        /// <returns></returns>
-        public async Task AssertNotArchived(Issue issue)
-        {
-            var project = await _projectRepository.GetAsync(issue.ProjectId);
-            var archivedState = project.States.Single(s => s.UserGenerated == false && s.Name == State.ArchivedState);
-
-            if (issue.StateId == archivedState.Id)
-            {
-                throw new HttpStatusException(403, "Issue is archived.");
-            }
-        }
     }
 }

--- a/Goose.API/Services/issues/IssueService.cs
+++ b/Goose.API/Services/issues/IssueService.cs
@@ -10,6 +10,7 @@ using Goose.Domain.Models.Projects;
 using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Http;
 using MongoDB.Bson;
+using Goose.API.Utils.Authentication;
 
 namespace Goose.API.Services.Issues
 {
@@ -38,14 +39,22 @@ namespace Goose.API.Services.Issues
         private readonly IIssueRepository _issueRepo;
         private readonly IIssueRequestValidator _issueValidator;
 
-        public IssueService(IIssueRepository issueRepo, IStateService stateService,
-            IProjectRepository projectRepository, IUserRepository userRepository, IIssueRequestValidator issueValidator)
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public IssueService(
+            IIssueRepository issueRepo,
+            IStateService stateService,
+            IProjectRepository projectRepository,
+            IUserRepository userRepository,
+            IIssueRequestValidator issueValidator,
+            IHttpContextAccessor httpContextAccessor)
         {
             _issueRepo = issueRepo;
             _stateService = stateService;
             _projectRepository = projectRepository;
             _userRepository = userRepository;
             _issueValidator = issueValidator;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         public async Task<IList<IssueDTO>> GetAll()
@@ -137,7 +146,7 @@ namespace Goose.API.Services.Issues
                     old.ConversationItems.Add(new IssueConversation()
                     {
                         Id = ObjectId.GenerateNewId(),
-                        CreatorUserId = null,
+                        CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                         Type = IssueConversation.StateChangeType,
                         Data = $"Status von {oldState.Name} zu {newState.Name} geändert.",
                     });
@@ -190,7 +199,7 @@ namespace Goose.API.Services.Issues
             issue.ConversationItems.Add(new IssueConversation()
             {
                 Id = ObjectId.GenerateNewId(),
-                CreatorUserId = null,
+                CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.ChildIssueAddedType,
                 Data = $"{issueId}",
             });
@@ -211,7 +220,7 @@ namespace Goose.API.Services.Issues
                 issue.ConversationItems.Add(new IssueConversation()
                 {
                     Id = ObjectId.GenerateNewId(),
-                    CreatorUserId = null,
+                    CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                     Type = IssueConversation.ChildIssueRemovedType,
                     Data = $"{issueId}",
                 });

--- a/Goose.API/Services/issues/IssueSummaryService.cs
+++ b/Goose.API/Services/issues/IssueSummaryService.cs
@@ -70,7 +70,7 @@ namespace Goose.API.Services.issues
                 CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.SummaryAcceptedType,
                 Data = "",
-                RequirementIds = issue.IssueDetail.Requirements.Select(x => x.Id).ToList(),
+                Requirements = issue.IssueDetail.Requirements.Select(x => x.Requirement).ToList(),
             });
             await _issueRepository.UpdateAsync(issue);
         }
@@ -95,7 +95,7 @@ namespace Goose.API.Services.issues
                 CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.SummaryCreatedType,
                 Data = "",
-                RequirementIds = issue.IssueDetail.Requirements.Select(x => x.Id).ToList(),
+                Requirements = issue.IssueDetail.Requirements.Select(x => x.Requirement).ToList(),
             });
             await _issueRepository.UpdateAsync(issue);
 
@@ -122,7 +122,7 @@ namespace Goose.API.Services.issues
                 CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.SummaryDeclinedType,
                 Data = "",
-                RequirementIds = issue.IssueDetail.Requirements.Select(x => x.Id).ToList(),
+                Requirements = issue.IssueDetail.Requirements.Select(x => x.Requirement).ToList(),
             });
             await _issueRepository.UpdateAsync(issue);
         }

--- a/Goose.API/Services/issues/IssueSummaryService.cs
+++ b/Goose.API/Services/issues/IssueSummaryService.cs
@@ -3,7 +3,7 @@ using Goose.API.Services.Issues;
 using Goose.API.Utils;
 using Goose.API.Utils.Exceptions;
 using Goose.Domain.Models.Projects;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Goose.API/Services/issues/IssueSummaryService.cs
+++ b/Goose.API/Services/issues/IssueSummaryService.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 
 namespace Goose.API.Services.issues
 {
@@ -55,6 +56,14 @@ namespace Goose.API.Services.issues
 
             issue.IssueDetail.RequirementsAccepted = true;
             issue.StateId = state.Id;
+            issue.ConversationItems.Add(new IssueConversation()
+            {
+                Id = ObjectId.GenerateNewId(),
+                CreatorUserId = null,
+                Type = IssueConversation.SummaryAcceptedType,
+                Data = "",
+                RequirementIds = issue.IssueDetail.Requirements.Select(x => x.Id).ToList(),
+            });
             await _issueRepository.UpdateAsync(issue);
         }
 
@@ -72,6 +81,14 @@ namespace Goose.API.Services.issues
                 throw new HttpStatusException(400, "Um eine Zusammenfassung erstellen zu können muss mindestens eine Anforderung oder eine geschätze Zeit vorhanden sein");
 
             issue.IssueDetail.RequirementsSummaryCreated = true;
+            issue.ConversationItems.Add(new IssueConversation()
+            {
+                Id = ObjectId.GenerateNewId(),
+                CreatorUserId = null,
+                Type = IssueConversation.SummaryCreatedType,
+                Data = "",
+                RequirementIds = issue.IssueDetail.Requirements.Select(x => x.Id).ToList(),
+            });
             await _issueRepository.UpdateAsync(issue);
 
             return await _issueRequirementService.GetAllOfIssueAsync(issueId.ToObjectId());
@@ -91,6 +108,14 @@ namespace Goose.API.Services.issues
                 throw new HttpStatusException(400, "Die Zusammenfassung wurde schon angenommen und kann nicht abgelehnt werden");
 
             issue.IssueDetail.RequirementsSummaryCreated = false;
+            issue.ConversationItems.Add(new IssueConversation()
+            {
+                Id = ObjectId.GenerateNewId(),
+                CreatorUserId = null,
+                Type = IssueConversation.SummaryDeclinedType,
+                Data = "",
+                RequirementIds = issue.IssueDetail.Requirements.Select(x => x.Id).ToList(),
+            });
             await _issueRepository.UpdateAsync(issue);
         }
 

--- a/Goose.API/Services/issues/IssueSummaryService.cs
+++ b/Goose.API/Services/issues/IssueSummaryService.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Bson;
+using Microsoft.AspNetCore.Http;
+using Goose.API.Utils.Authentication;
 
 namespace Goose.API.Services.issues
 {
@@ -25,12 +27,18 @@ namespace Goose.API.Services.issues
         private readonly IIssueRepository _issueRepository;
         private readonly IIssueRequirementService _issueRequirementService;
         private readonly IStateService _stateService;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public IssueSummaryService(IIssueRepository issueRepository, IIssueRequirementService issueRequirementService, IStateService stateService)
+        public IssueSummaryService(
+            IIssueRepository issueRepository,
+            IIssueRequirementService issueRequirementService,
+            IStateService stateService,
+            IHttpContextAccessor httpContextAccessor)
         {
             _issueRepository = issueRepository;
             _issueRequirementService = issueRequirementService;
             _stateService = stateService;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         public async Task AcceptSummary(string issueId)
@@ -59,7 +67,7 @@ namespace Goose.API.Services.issues
             issue.ConversationItems.Add(new IssueConversation()
             {
                 Id = ObjectId.GenerateNewId(),
-                CreatorUserId = null,
+                CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.SummaryAcceptedType,
                 Data = "",
                 RequirementIds = issue.IssueDetail.Requirements.Select(x => x.Id).ToList(),
@@ -84,7 +92,7 @@ namespace Goose.API.Services.issues
             issue.ConversationItems.Add(new IssueConversation()
             {
                 Id = ObjectId.GenerateNewId(),
-                CreatorUserId = null,
+                CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.SummaryCreatedType,
                 Data = "",
                 RequirementIds = issue.IssueDetail.Requirements.Select(x => x.Id).ToList(),
@@ -111,7 +119,7 @@ namespace Goose.API.Services.issues
             issue.ConversationItems.Add(new IssueConversation()
             {
                 Id = ObjectId.GenerateNewId(),
-                CreatorUserId = null,
+                CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.SummaryDeclinedType,
                 Data = "",
                 RequirementIds = issue.IssueDetail.Requirements.Select(x => x.Id).ToList(),

--- a/Goose.API/Services/issues/IssueTimeSheetService.cs
+++ b/Goose.API/Services/issues/IssueTimeSheetService.cs
@@ -4,10 +4,8 @@ using System.Threading.Tasks;
 using Goose.API.Repositories;
 using Goose.Domain.DTOs;
 using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Goose.API.Utils;
-using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.Tickets;
 using MongoDB.Bson;
 
 namespace Goose.API.Services.Issues

--- a/Goose.Domain/DTOs/Issues/IssueConversationDTO.cs
+++ b/Goose.Domain/DTOs/Issues/IssueConversationDTO.cs
@@ -11,18 +11,18 @@ namespace Goose.Domain.DTOs.Issues
         public UserDTO Creator { get; set; }
         public string Type { get; set; }
         public string Data { get; set; }
-        public IList<IssueRequirement> Requirements { get; set; }
+        public IList<string> Requirements { get; set; }
         public DateTime CreatedAt { get; set; }
 
         public IssueConversationDTO() { }
 
-        public IssueConversationDTO(IssueConversation issueConversation, UserDTO creator, IList<IssueRequirement> requirements)
+        public IssueConversationDTO(IssueConversation issueConversation, UserDTO creator)
         {
             Id = issueConversation.Id;
             Creator = creator;
             Type = issueConversation.Type;
             Data = issueConversation.Data;
-            Requirements = requirements;
+            Requirements = issueConversation.Requirements;
             CreatedAt = issueConversation.CreatedAt;
         }
     }

--- a/Goose.Domain/DTOs/Issues/IssueConversationDTO.cs
+++ b/Goose.Domain/DTOs/Issues/IssueConversationDTO.cs
@@ -1,4 +1,4 @@
-﻿using Goose.Domain.Models.Tickets;
+﻿using Goose.Domain.Models.Issues;
 using MongoDB.Bson;
 using System;
 using System.Collections.Generic;

--- a/Goose.Domain/DTOs/Issues/IssueConversationDTO.cs
+++ b/Goose.Domain/DTOs/Issues/IssueConversationDTO.cs
@@ -3,7 +3,7 @@ using MongoDB.Bson;
 using System;
 using System.Collections.Generic;
 
-namespace Goose.Domain.DTOs.Tickets
+namespace Goose.Domain.DTOs.Issues
 {
     public class IssueConversationDTO
     {

--- a/Goose.Domain/DTOs/issues/IssueDTO.cs
+++ b/Goose.Domain/DTOs/issues/IssueDTO.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using MongoDB.Bson;
 
 namespace Goose.Domain.DTOs.Issues

--- a/Goose.Domain/DTOs/issues/IssueDTODetailed.cs
+++ b/Goose.Domain/DTOs/issues/IssueDTODetailed.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 using System.Collections.Generic;
-using Goose.Domain.DTOs.Tickets;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.DTOs.Issues;
+using Goose.Domain.Models.Issues;
 using MongoDB.Bson;
 
 namespace Goose.Domain.DTOs.Issues

--- a/Goose.Domain/DTOs/issues/IssueTimeSheetDTO.cs
+++ b/Goose.Domain/DTOs/issues/IssueTimeSheetDTO.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Goose.Domain.Models.Identity;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using MongoDB.Bson;
 
 namespace Goose.Domain.DTOs.Issues

--- a/Goose.Domain/Mappings/AutoMapping.cs
+++ b/Goose.Domain/Mappings/AutoMapping.cs
@@ -1,9 +1,8 @@
 ﻿using AutoMapper;
 using Goose.Domain.DTOs;
 using Goose.Domain.DTOs.Issues;
-using Goose.Domain.Models.identity;
-using Goose.Domain.Models.tickets;
-using Goose.Domain.DTOs.tickets;
+using Goose.Domain.Models.Identity;
+using Goose.Domain.Models.Issues;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/Goose.Domain/Models/tickets/Issue.cs
+++ b/Goose.Domain/Models/tickets/Issue.cs
@@ -4,7 +4,7 @@ using Goose.Domain.Models.Identity;
 using Goose.Domain.Models.Projects;
 using MongoDB.Bson;
 
-namespace Goose.Domain.Models.Tickets
+namespace Goose.Domain.Models.Issues
 {
     public class Issue : Document
     {

--- a/Goose.Domain/Models/tickets/IssueConversation.cs
+++ b/Goose.Domain/Models/tickets/IssueConversation.cs
@@ -13,7 +13,8 @@ namespace Goose.Domain.Models.Issues
         public ObjectId? CreatorUserId { get; set; }
         public string Type { get; set; }
         public string Data { get; set; }
-        public IList<ObjectId> RequirementIds { get; set; }
+        public IList<string> Requirements { get; set; }
+
         public DateTime CreatedAt { get => Id.CreationTime; }
 
 

--- a/Goose.Domain/Models/tickets/IssueConversation.cs
+++ b/Goose.Domain/Models/tickets/IssueConversation.cs
@@ -25,7 +25,6 @@ namespace Goose.Domain.Models.Issues
         public const string PredecessorAddedType = "Vorgänger hinzugefügt";
         public const string PredecessorRemovedType = "Vorgänger entfernt";
         public const string ChildIssueAddedType = "Unterticket hinzugefügt";
-        // TODO brauchen wir das?
         public const string ChildIssueRemovedType = "Unterticket entfernt";
     }
 }

--- a/Goose.Domain/Models/tickets/IssueConversation.cs
+++ b/Goose.Domain/Models/tickets/IssueConversation.cs
@@ -4,7 +4,7 @@ using Goose.Domain.Models.Identity;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
-namespace Goose.Domain.Models.Tickets
+namespace Goose.Domain.Models.Issues
 {
     public class IssueConversation
     {

--- a/Goose.Domain/Models/tickets/IssueConversation.cs
+++ b/Goose.Domain/Models/tickets/IssueConversation.cs
@@ -10,10 +10,22 @@ namespace Goose.Domain.Models.Tickets
     {
         [BsonId]
         public ObjectId Id { get; set; }
-        public ObjectId CreatorUserId { get; set; }
+        public ObjectId? CreatorUserId { get; set; }
         public string Type { get; set; }
         public string Data { get; set; }
         public IList<ObjectId> RequirementIds { get; set; }
         public DateTime CreatedAt { get => Id.CreationTime; }
+
+
+        public const string MessageType = "Nachricht";
+        public const string StateChangeType = "Statusänderung";
+        public const string SummaryCreatedType = "Zusammenfassung";
+        public const string SummaryAcceptedType = "Zusammenfassung akzeptiert";
+        public const string SummaryDeclinedType = "Zusammenfassung abgelehnt";
+        public const string PredecessorAddedType = "Vorgänger hinzugefügt";
+        public const string PredecessorRemovedType = "Vorgänger entfernt";
+        public const string ChildIssueAddedType = "Unterticket hinzugefügt";
+        // TODO brauchen wir das?
+        public const string ChildIssueRemovedType = "Unterticket entfernt";
     }
 }

--- a/Goose.Domain/Models/tickets/IssueDetail.cs
+++ b/Goose.Domain/Models/tickets/IssueDetail.cs
@@ -2,9 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using static Goose.Domain.Models.Tickets.Issue;
+using static Goose.Domain.Models.Issues.Issue;
 
-namespace Goose.Domain.Models.Tickets
+namespace Goose.Domain.Models.Issues
 {
     public class IssueDetail
     {

--- a/Goose.Domain/Models/tickets/IssueRequirement.cs
+++ b/Goose.Domain/Models/tickets/IssueRequirement.cs
@@ -1,6 +1,6 @@
 ﻿using MongoDB.Bson;
 
-namespace Goose.Domain.Models.Tickets
+namespace Goose.Domain.Models.Issues
 {
     public class IssueRequirement
     {

--- a/Goose.Domain/Models/tickets/TimeSheet.cs
+++ b/Goose.Domain/Models/tickets/TimeSheet.cs
@@ -3,7 +3,7 @@ using Goose.Domain.Models.Identity;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
-namespace Goose.Domain.Models.Tickets
+namespace Goose.Domain.Models.Issues
 {
     public class TimeSheet
     {

--- a/Goose.Tests/Application.IntegrationTests/Company/CompanyUserTest.cs
+++ b/Goose.Tests/Application.IntegrationTests/Company/CompanyUserTest.cs
@@ -40,13 +40,13 @@ namespace Goose.Tests.Application.IntegrationTests.Company
         [OneTimeTearDown]
         public async Task OneTimeTearDown()
         {
-            await TestHelper.Instance.ClearCompany(_companyRepository, _userRepository);
+            await TestHelper.Instance.ClearCompany();
         }
 
         [SetUp]
         public async Task Setup()
         {
-            await TestHelper.Instance.ClearCompany(_companyRepository, _userRepository);
+            await TestHelper.Instance.ClearCompany();
             signInObject = await TestHelper.Instance.GenerateCompany(_client);
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", signInObject.Token);
         }
@@ -54,7 +54,7 @@ namespace Goose.Tests.Application.IntegrationTests.Company
         [Test]
         public async Task CreateUserTrue()
         {
-            var company = (await _companyRepository.FilterByAsync(x => x.Name.Equals(TestHelper.FirmenName))).FirstOrDefault();
+            var company = await TestHelper.Instance.GetCompany();
             var uri = $"api/companies/{company.Id}/users";
 
             PropertyUserLoginDTO user = GetUser("Phillip", "Schmidt", "Test123456", new List<RoleDTO>() { new RoleDTO() { Name = "Mitarbeiter" } });
@@ -76,7 +76,7 @@ namespace Goose.Tests.Application.IntegrationTests.Company
         [Test]
         public async Task CreateUserWithOutCompanyRole()
         {
-            var company = (await _companyRepository.FilterByAsync(x => x.Name.Equals(TestHelper.FirmenName))).FirstOrDefault();
+            var company = await TestHelper.Instance.GetCompany();
             var uri = $"api/companies/{company.Id}/users";
 
             PropertyUserLoginDTO user = GetUser("Phillip", "Schmidt", "Test123456", new List<RoleDTO>() { new RoleDTO() { Name = "Mitarbeiter" } });
@@ -106,7 +106,7 @@ namespace Goose.Tests.Application.IntegrationTests.Company
         [Test]
         public async Task CreateUserFirstNameFalse()
         {
-            var company = (await _companyRepository.FilterByAsync(x => x.Name.Equals(TestHelper.FirmenName))).FirstOrDefault();
+            var company = await TestHelper.Instance.GetCompany();
             var uri = $"api/companies/{company.Id}/users";
 
             PropertyUserLoginDTO user = GetUser(" ", "Schmidt", "Test123456", new List<RoleDTO>() { new RoleDTO() { Name = "Mitarbeiter" } });
@@ -119,7 +119,7 @@ namespace Goose.Tests.Application.IntegrationTests.Company
         [Test]
         public async Task CreateUserLastNameFalse()
         {
-            var company = (await _companyRepository.FilterByAsync(x => x.Name.Equals(TestHelper.FirmenName))).FirstOrDefault();
+            var company = await TestHelper.Instance.GetCompany();
             var uri = $"api/companies/{company.Id}/users";
 
             PropertyUserLoginDTO user = GetUser("Phillip", " ", "Test123456", new List<RoleDTO>() { new RoleDTO() { Name = "Mitarbeiter" } });

--- a/Goose.Tests/Application.IntegrationTests/TestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/TestHelper.cs
@@ -3,7 +3,7 @@ using Goose.Domain.DTOs;
 using Goose.Domain.DTOs.Issues;
 using Goose.Domain.Models.Auth;
 using Goose.Domain.Models.Projects;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Goose.Tests/Application.IntegrationTests/TestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/TestHelper.cs
@@ -39,6 +39,7 @@ namespace Goose.Tests.Application.IntegrationTests
         private readonly ICompanyRepository _companyRepository;
         private readonly IUserRepository _userRepository;
         private readonly IIssueRepository _issueRepository;
+        private readonly IRoleRepository _roleRepository;
         private readonly IProjectRepository _projectRepository;
 
         // Hier werden alle TestIssues gespeichert, die sich in der DB befinden.
@@ -53,6 +54,7 @@ namespace Goose.Tests.Application.IntegrationTests
             _companyRepository = scope.ServiceProvider.GetService<ICompanyRepository>();
             _userRepository = scope.ServiceProvider.GetService<IUserRepository>();
             _projectRepository = scope.ServiceProvider.GetService<IProjectRepository>();
+            _roleRepository = scope.ServiceProvider.GetService<IRoleRepository>();
             _issueRepository = scope.ServiceProvider.GetService<IIssueRepository>();
         }
 
@@ -117,6 +119,24 @@ namespace Goose.Tests.Application.IntegrationTests
             var uri = $"api/companies/{company.Id}/projects";
             var newProject = new ProjectDTO() { Name = ProjektName };
             await client.PostAsync(uri, newProject.ToStringContent());
+        }
+
+        public async Task AddUserToProject(HttpClient client, string roleName)
+        {
+            // add user to company
+            var user = await GetUser();
+            var project = await GetProject();
+            var role = (await _roleRepository.FilterByAsync(x => x.Name == roleName)).Single();
+            var uri = $"api/projects/{project.Id}/users/{user.Id}";
+            var addRequest = new PropertyUserDTO()
+            {
+                User = new UserDTO(user),
+                Roles = new List<RoleDTO>()
+                {
+                    new RoleDTO(role),
+                }
+            };
+            await client.PutAsync(uri, addRequest.ToStringContent());
         }
 
         public async Task GenerateIssue(HttpClient httpClient, int index = 0)

--- a/Goose.Tests/Application.IntegrationTests/TestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/TestHelper.cs
@@ -49,13 +49,11 @@ namespace Goose.Tests.Application.IntegrationTests
             var factory = new WebApplicationFactory<Startup>();
             var scopeFactory = factory.Server.Services.GetService<IServiceScopeFactory>();
 
-            using (var scope = scopeFactory.CreateScope())
-            {
-                _companyRepository = scope.ServiceProvider.GetService<ICompanyRepository>();
-                _userRepository = scope.ServiceProvider.GetService<IUserRepository>();
-                _projectRepository = scope.ServiceProvider.GetService<IProjectRepository>();
-                _issueRepository = scope.ServiceProvider.GetService<IIssueRepository>();
-            }
+            using var scope = scopeFactory.CreateScope();
+            _companyRepository = scope.ServiceProvider.GetService<ICompanyRepository>();
+            _userRepository = scope.ServiceProvider.GetService<IUserRepository>();
+            _projectRepository = scope.ServiceProvider.GetService<IProjectRepository>();
+            _issueRepository = scope.ServiceProvider.GetService<IIssueRepository>();
         }
 
         public static TestHelper Instance

--- a/Goose.Tests/Application.IntegrationTests/TestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/TestHelper.cs
@@ -138,7 +138,7 @@ namespace Goose.Tests.Application.IntegrationTests
                 Author = new UserDTO(user),
                 Client = new UserDTO(user),
                 Project = new ProjectDTO(project),
-                State = await GetStateByName(httpClient, project.Id.ToString(), State.NegotiationState),
+                State = await GetStateByName(httpClient, project.Id, State.NegotiationState),
                 IssueDetail = new IssueDetail
                 {
                     Name = TicketName,
@@ -181,14 +181,14 @@ namespace Goose.Tests.Application.IntegrationTests
 
 
         #region Getting
-        private async Task<IList<StateDTO>> GetStateList(HttpClient client, string projectId)
+        private async Task<IList<StateDTO>> GetStateList(HttpClient client, ObjectId projectId)
         {
             var uri = $"api/projects/{projectId}/states";
             var responce = await client.GetAsync(uri);
             return await responce.Content.Parse<IList<StateDTO>>();
         }
 
-        public async Task<StateDTO> GetStateByName(HttpClient client, string projectId, string name)
+        public async Task<StateDTO> GetStateByName(HttpClient client, ObjectId projectId, string name)
         {
             return (await GetStateList(client, projectId)).FirstOrDefault(x => x.Name.Equals(name));
         }

--- a/Goose.Tests/Application.IntegrationTests/TestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/TestHelper.cs
@@ -86,7 +86,7 @@ namespace Goose.Tests.Application.IntegrationTests
             var company = (await companyRepository.FilterByAsync(x => x.Name.Equals(FirmenName))).FirstOrDefault();
             var project = (await projectRepository.FilterByAsync(x => x.ProjectDetail.Name.Equals(ProjektName))).FirstOrDefault();
 
-            var propertyUser = company.Users.FirstOrDefault(x => x != null);
+            var propertyUser = company.Users.FirstOrDefault();
             var user = (await userRepository.FilterByAsync(x => x.Id.Equals(propertyUser.UserId))).FirstOrDefault();
 
             var uri = $"api/projects/{project.Id}/issues/";
@@ -100,7 +100,7 @@ namespace Goose.Tests.Application.IntegrationTests
                 IssueDetail = new IssueDetail
                 {
                     Name = TicketName,
-                    Type = null,
+                    Type = Issue.TypeFeature,
                     StartDate = default,
                     EndDate = default,
                     ExpectedTime = 0,
@@ -115,7 +115,7 @@ namespace Goose.Tests.Application.IntegrationTests
                     RelevantDocuments = null
                 }
             };
-            await client.PostAsync(uri, issue.ToStringContent());
+            var postResult = await client.PostAsync(uri, issue.ToStringContent());
         }
 
         private async Task<IList<StateDTO>> GetStateList(HttpClient client, string projectId)
@@ -128,6 +128,12 @@ namespace Goose.Tests.Application.IntegrationTests
         public async Task<StateDTO> GetStateByName(HttpClient client, string projectId, string name)
         {
             return (await GetStateList(client, projectId)).FirstOrDefault(x => x.Name.Equals(name));
+        }
+
+        public async Task<Issue> GetIssueAsync(IIssueRepository issueRepository)
+        {
+            var issues = await issueRepository.FilterByAsync(x => x.IssueDetail.Name == TestHelper.TicketName);
+            return issues.FirstOrDefault();
         }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
@@ -1,8 +1,10 @@
 ﻿using Goose.API;
 using Goose.API.Repositories;
+using Goose.Domain.DTOs;
 using Goose.Domain.DTOs.Issues;
 using Goose.Domain.Models.Auth;
 using Goose.Domain.Models.Issues;
+using Goose.Domain.Models.Projects;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -59,9 +61,143 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             Assert.IsTrue(response.IsSuccessStatusCode);
 
             issue = await TestHelper.Instance.GetIssueAsync();
-            var newConversationItem = issue.ConversationItems.Last();
-            Assert.AreEqual(newConversationItem.Type, IssueConversation.MessageType);
-            Assert.AreEqual(newConversationItem.Data, "TestConversation");
+            var latestConversationItem = issue.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            Assert.AreEqual(latestConversationItem.Type, IssueConversation.MessageType);
+            Assert.AreEqual(latestConversationItem.Data, "TestConversation");
+        }
+
+        [Test]
+        public async Task PostConversationWrongType()
+        {
+            var user = await TestHelper.Instance.GetUser();
+
+            var newItem = new IssueConversationDTO()
+            {
+                Creator = new Domain.DTOs.UserDTO(user),
+                Type = IssueConversation.StateChangeType,
+                Data = "TestConversation",
+            };
+
+            var issue = await TestHelper.Instance.GetIssueAsync();
+            var uri = $"/api/issues/{issue.Id}/conversations/";
+
+            var response = await _client.PostAsync(uri, newItem.ToStringContent());
+            Assert.IsFalse(response.IsSuccessStatusCode);
+
+            issue = await TestHelper.Instance.GetIssueAsync();
+            Assert.AreEqual(0, issue.ConversationItems.Count);
+        }
+
+        [Test]
+        public async Task PredecessorConversation()
+        {
+            await TestHelper.Instance.GenerateIssue(_client, 1);
+            var predecessorIssue = await TestHelper.Instance.GetIssueAsync(1);
+
+            var user = await TestHelper.Instance.GetUser();
+
+            var issue = await TestHelper.Instance.GetIssueAsync();
+            var uri = $"/api/issues/{issue.Id}/predecessors/{predecessorIssue.Id}";
+
+            // Add the predecessor
+            var response = await _client.PutAsync(uri, null);
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            issue = await TestHelper.Instance.GetIssueAsync();
+            var latestConversationItem = issue.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            Assert.AreEqual(latestConversationItem.Type, IssueConversation.PredecessorAddedType);
+            Assert.AreEqual(latestConversationItem.Data, predecessorIssue.Id.ToString());
+
+            // Remove the predecessor
+            response = await _client.DeleteAsync(uri);
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            issue = await TestHelper.Instance.GetIssueAsync();
+            latestConversationItem = issue.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            Assert.AreEqual(latestConversationItem.Type, IssueConversation.PredecessorRemovedType);
+            Assert.AreEqual(latestConversationItem.Data, predecessorIssue.Id.ToString());
+        }
+
+        [Test]
+        public async Task ChildConversation()
+        {
+            await TestHelper.Instance.GenerateIssue(_client, 1);
+            var childIssue = await TestHelper.Instance.GetIssueAsync(1);
+
+            var user = await TestHelper.Instance.GetUser();
+
+            var issue = await TestHelper.Instance.GetIssueAsync();
+            var addUri = $"/api/issues/{childIssue.Id}/parent/{issue.Id}";
+            var removeUri = $"/api/issues/{childIssue.Id}/parent";
+
+            // Add the parent
+            var response = await _client.PutAsync(addUri, null);
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            issue = await TestHelper.Instance.GetIssueAsync();
+            var latestConversationItem = issue.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            Assert.AreEqual(latestConversationItem.Type, IssueConversation.ChildIssueAddedType);
+            Assert.AreEqual(latestConversationItem.Data, childIssue.Id.ToString());
+
+            // Remove the parent
+            response = await _client.DeleteAsync(removeUri);
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            issue = await TestHelper.Instance.GetIssueAsync();
+            latestConversationItem = issue.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            Assert.AreEqual(latestConversationItem.Type, IssueConversation.ChildIssueRemovedType);
+            Assert.AreEqual(latestConversationItem.Data, childIssue.Id.ToString());
+        }
+
+        [Test]
+        public async Task StatusConversation()
+        {
+            var user = await TestHelper.Instance.GetUser();
+            var project = await TestHelper.Instance.GetProject();
+
+            var issue = await TestHelper.Instance.GetIssueAsync();
+            var uri = $"/api/projects/{project.Id}/issues/{issue.Id}";
+
+            var newState = await TestHelper.Instance.GetStateByName(_client, issue.ProjectId, State.NegotiationState);
+            var userDTO = new UserDTO(user);
+            var issueDTO = new IssueDTO(issue, newState, new ProjectDTO(project), userDTO, userDTO);
+
+            var response = await _client.PutAsync(uri, issueDTO.ToStringContent());
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            issue = await TestHelper.Instance.GetIssueAsync();
+            var latestConversationItem = issue.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            Assert.AreEqual(latestConversationItem.Type, IssueConversation.StateChangeType);
+            Assert.AreNotEqual(latestConversationItem.Data, "");
+        }
+
+        [Test]
+        public async Task SummaryConversation()
+        {
+            var user = await TestHelper.Instance.GetUser();
+            var project = await TestHelper.Instance.GetProject();
+
+            var issue = await TestHelper.Instance.GetIssueAsync();
+            var uri = $"/api/projects/{project.Id}/issues/{issue.Id}";
+
+            var newState = await TestHelper.Instance.GetStateByName(_client, issue.ProjectId, State.NegotiationState);
+            var userDTO = new UserDTO(user);
+            var issueDTO = new IssueDTO(issue, newState, new ProjectDTO(project), userDTO, userDTO);
+
+            var response = await _client.PutAsync(uri, issueDTO.ToStringContent());
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            issue = await TestHelper.Instance.GetIssueAsync();
+            var latestConversationItem = issue.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            Assert.AreEqual(latestConversationItem.Type, IssueConversation.StateChangeType);
+            Assert.AreNotEqual(latestConversationItem.Data, "");
         }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
@@ -20,43 +20,26 @@ namespace Goose.Tests.Application.IntegrationTests.issues
     class IssueConversationTests
     {
         private HttpClient _client;
-        private WebApplicationFactory<Startup> _factory;
-        private ICompanyRepository _companyRepository;
-        private IUserRepository _userRepository;
-        private IIssueRepository _issueRepository;
-        private IProjectRepository _projectRepository;
-        private SignInResponse signInObject;
 
         [OneTimeSetUp]
         public void OneTimeSetup()
         {
-            _factory = new WebApplicationFactory<Startup>();
-            _client = _factory.CreateClient();
-            var scopeFactory = _factory.Server.Services.GetService<IServiceScopeFactory>();
-
-            using (var scope = scopeFactory.CreateScope())
-            {
-                _companyRepository = scope.ServiceProvider.GetService<ICompanyRepository>();
-                _userRepository = scope.ServiceProvider.GetService<IUserRepository>();
-                _projectRepository = scope.ServiceProvider.GetService<IProjectRepository>();
-                _issueRepository = scope.ServiceProvider.GetService<IIssueRepository>();
-            }
-        }
-
-        [OneTimeTearDown]
-        public async Task OneTimeTearDown()
-        {
-            await Clear();
+            var factory = new WebApplicationFactory<Startup>();
+            _client = factory.CreateClient();
         }
 
         [SetUp]
         public async Task Setup()
         {
-            await Clear();
-            await Generate();
+            await TestHelper.Instance.GenerateAll(_client);
         }
 
-        // TODO add tests
+        [TearDown]
+        public async Task Teardown()
+        {
+            await TestHelper.Instance.ClearAll();
+        }
+
         [Test]
         public async Task PostConversation()
         {
@@ -79,19 +62,6 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var newConversationItem = issue.ConversationItems.Last();
             Assert.AreEqual(newConversationItem.Type, IssueConversation.MessageType);
             Assert.AreEqual(newConversationItem.Data, "TestConversation");
-        }
-
-        private async Task Clear()
-        {
-            await TestHelper.Instance.ClearAll();
-        }
-
-        private async Task Generate()
-        {
-            signInObject = await TestHelper.Instance.GenerateCompany(_client);
-            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", signInObject.Token);
-            await TestHelper.Instance.GenerateProject(_client);
-            await TestHelper.Instance.GenerateIssue(_client);
         }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
@@ -203,7 +203,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var latestConversationItem = issue.ConversationItems.Last();
             Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.SummaryCreatedType);
-            Assert.AreEqual(latestConversationItem.RequirementIds.Single(), issueRequirement.Id);
+            Assert.AreEqual(latestConversationItem.Requirements.Single(), issueRequirement.Requirement);
 
             // Accept the summary
             uri = $"/api/issues/{issue.Id}/summaries?accept=true";
@@ -215,7 +215,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             latestConversationItem = issue.ConversationItems.Last();
             Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.SummaryAcceptedType);
-            Assert.AreEqual(latestConversationItem.RequirementIds.Single(), issueRequirement.Id);
+            Assert.AreEqual(latestConversationItem.Requirements.Single(), issueRequirement.Requirement);
         }
 
         [Test]
@@ -237,7 +237,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var latestConversationItem = issue.ConversationItems.Last();
             Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.SummaryCreatedType);
-            Assert.AreEqual(latestConversationItem.RequirementIds.Single(), issueRequirement.Id);
+            Assert.AreEqual(latestConversationItem.Requirements.Single(), issueRequirement.Requirement);
 
             // Decline the summary
             uri = $"/api/issues/{issue.Id}/summaries?accept=false";
@@ -249,7 +249,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             latestConversationItem = issue.ConversationItems.Last();
             Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.SummaryDeclinedType);
-            Assert.AreEqual(latestConversationItem.RequirementIds.Single(), issueRequirement.Id);
+            Assert.AreEqual(latestConversationItem.Requirements.Single(), issueRequirement.Requirement);
         }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
@@ -1,0 +1,94 @@
+﻿using Goose.API;
+using Goose.API.Repositories;
+using Goose.Domain.DTOs.Issues;
+using Goose.Domain.Models.Auth;
+using Goose.Domain.Models.Issues;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Goose.Tests.Application.IntegrationTests.issues
+{
+    [TestFixture]
+    class IssueConversationTests
+    {
+        private HttpClient _client;
+        private WebApplicationFactory<Startup> _factory;
+        private ICompanyRepository _companyRepository;
+        private IUserRepository _userRepository;
+        private IIssueRepository _issueRepository;
+        private IProjectRepository _projectRepository;
+        private SignInResponse signInObject;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            _factory = new WebApplicationFactory<Startup>();
+            _client = _factory.CreateClient();
+            var scopeFactory = _factory.Server.Services.GetService<IServiceScopeFactory>();
+
+            using (var scope = scopeFactory.CreateScope())
+            {
+                _companyRepository = scope.ServiceProvider.GetService<ICompanyRepository>();
+                _userRepository = scope.ServiceProvider.GetService<IUserRepository>();
+                _projectRepository = scope.ServiceProvider.GetService<IProjectRepository>();
+                _issueRepository = scope.ServiceProvider.GetService<IIssueRepository>();
+            }
+        }
+
+        [OneTimeTearDown]
+        public async Task OneTimeTearDown()
+        {
+            await Clear();
+        }
+
+        [SetUp]
+        public async Task Setup()
+        {
+            await Clear();
+            await Generate();
+        }
+
+        // TODO add tests
+        [Test]
+        public async Task PostConversation()
+        {
+            var newItem = new IssueConversationDTO()
+            {
+                Type = IssueConversation.MessageType,
+                Data = "TestConversation",
+            };
+
+            var issue = await TestHelper.Instance.GetIssueAsync(_issueRepository);
+            var uri = $"/api/issues/{issue.Id}/conversations/";
+
+            var response = await _client.PostAsync(uri, newItem.ToStringContent());
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            issue = await TestHelper.Instance.GetIssueAsync(_issueRepository);
+            Assert.IsTrue(issue.ConversationItems.Last().Data == "TestConversation");
+        }
+
+        private async Task Clear()
+        {
+            await TestHelper.Instance.ClearCompany(_companyRepository, _userRepository);
+            await TestHelper.Instance.ClearProject(_projectRepository);
+            await TestHelper.Instance.ClearIssue(_issueRepository);
+        }
+
+        private async Task Generate()
+        {
+            signInObject = await TestHelper.Instance.GenerateCompany(_client);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", signInObject.Token);
+            await TestHelper.Instance.GenerateProject(_client, _companyRepository);
+            await TestHelper.Instance.GenerateIssue(_client, _companyRepository, _projectRepository, _userRepository);
+        }
+    }
+}

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
@@ -4,6 +4,7 @@ using Goose.API.Services.Issues;
 using Goose.Domain.DTOs;
 using Goose.Domain.DTOs.Issues;
 using Goose.Domain.Models.Auth;
+using Goose.Domain.Models.Identity;
 using Goose.Domain.Models.Issues;
 using Goose.Domain.Models.Projects;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -52,11 +53,12 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task PostConversation()
         {
+            await TestHelper.Instance.AddUserToProject(_client, Role.ProjectLeaderRole);
+
             var user = await TestHelper.Instance.GetUser();
 
             var newItem = new IssueConversationDTO()
             {
-                Creator = new Domain.DTOs.UserDTO(user),
                 Type = IssueConversation.MessageType,
                 Data = "TestConversation",
             };
@@ -77,11 +79,8 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task PostConversationWrongType()
         {
-            var user = await TestHelper.Instance.GetUser();
-
             var newItem = new IssueConversationDTO()
             {
-                Creator = new Domain.DTOs.UserDTO(user),
                 Type = IssueConversation.StateChangeType,
                 Data = "TestConversation",
             };

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
@@ -16,27 +16,12 @@ namespace Goose.Tests.Application.IntegrationTests.issues
     class IssueRequirementTests
     {
         private HttpClient _client;
-        private WebApplicationFactory<Startup> _factory;
-        private ICompanyRepository _companyRepository;
-        private IUserRepository _userRepository;
-        private IIssueRepository _issueRepository;
-        private IProjectRepository _projectRepository;
-        private SignInResponse signInObject;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            _factory = new WebApplicationFactory<Startup>();
-            _client = _factory.CreateClient();
-            var scopeFactory = _factory.Server.Services.GetService<IServiceScopeFactory>();
-
-            using (var scope = scopeFactory.CreateScope())
-            {
-                _companyRepository = scope.ServiceProvider.GetService<ICompanyRepository>();
-                _userRepository = scope.ServiceProvider.GetService<IUserRepository>();
-                _projectRepository = scope.ServiceProvider.GetService<IProjectRepository>();
-                _issueRepository = scope.ServiceProvider.GetService<IIssueRepository>();
-            }
+            var factory = new WebApplicationFactory<Startup>();
+            _client = factory.CreateClient();
         }
 
         [OneTimeTearDown]
@@ -48,8 +33,13 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [SetUp]
         public async Task Setup()
         {
-            await Clear();
-            await Generate();
+            await TestHelper.Instance.GenerateAll(_client);
+        }
+
+        [TearDown]
+        public async Task TearDown()
+        {
+            await TestHelper.Instance.ClearAll();
         }
 
         [Test]
@@ -98,16 +88,6 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             issue = await TestHelper.Instance.GetIssueAsync();
             var exits = issue.IssueDetail.Requirements?.FirstOrDefault(x => x.Requirement.Equals("Die Application Testen")) != null;
             Assert.IsFalse(exits);
-        }
-
-        private async Task Clear()
-        {
-            await TestHelper.Instance.ClearAll();
-        }
-
-        private async Task Generate()
-        {
-            await TestHelper.Instance.GenerateAll(_client);
         }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
@@ -50,7 +50,6 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         {
             await Clear();
             await Generate();
-            
         }
 
         [Test]

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
@@ -55,13 +55,13 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task AddRequirement()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            var issue = await TestHelper.Instance.GetIssueAsync();
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
             var uri = $"/api/issues/{issue.Id}/requirements/";
             var responce = await _client.PostAsync(uri, issueRequirement.ToStringContent());
             Assert.IsTrue(responce.IsSuccessStatusCode);
 
-            issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            issue = await TestHelper.Instance.GetIssueAsync();
             var exits = issue.IssueDetail.Requirements?.FirstOrDefault(x => x.Requirement.Equals("Die Application Testen")) != null;
             Assert.IsTrue(exits);
         }
@@ -69,13 +69,13 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task AddRequirementFalse()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            var issue = await TestHelper.Instance.GetIssueAsync();
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = " " };
             var uri = $"/api/issues/{issue.Id}/requirements/";
             var responce = await _client.PostAsync(uri, issueRequirement.ToStringContent());
             Assert.IsFalse(responce.IsSuccessStatusCode);
 
-            issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            issue = await TestHelper.Instance.GetIssueAsync();
             var exits = issue.IssueDetail.Requirements?.FirstOrDefault(x => x.Requirement.Equals("Die Application Testen")) != null;
             Assert.IsFalse(exits);
         }
@@ -83,36 +83,31 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task DeleteRequirement()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            var issue = await TestHelper.Instance.GetIssueAsync();
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
             var uri = $"/api/issues/{issue.Id}/requirements/";
             var responce = await _client.PostAsync(uri, issueRequirement.ToStringContent());
             Assert.IsTrue(responce.IsSuccessStatusCode);
 
-            issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            issue = await TestHelper.Instance.GetIssueAsync();
             var addedRequirement = issue.IssueDetail.Requirements?.FirstOrDefault(x => x.Requirement.Equals("Die Application Testen"));
             uri = $"/api/issues/{issue.Id}/requirements/{addedRequirement.Id}";
             responce = await _client.DeleteAsync(uri);
             Assert.IsTrue(responce.IsSuccessStatusCode);
 
-            issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            issue = await TestHelper.Instance.GetIssueAsync();
             var exits = issue.IssueDetail.Requirements?.FirstOrDefault(x => x.Requirement.Equals("Die Application Testen")) != null;
             Assert.IsFalse(exits);
         }
 
         private async Task Clear()
         {
-            await TestHelper.Instance.ClearCompany(_companyRepository, _userRepository);
-            await TestHelper.Instance.ClearProject(_projectRepository);
-            await TestHelper.Instance.ClearIssue(_issueRepository);
+            await TestHelper.Instance.ClearAll();
         }
 
         private async Task Generate()
         {
-            signInObject = await TestHelper.Instance.GenerateCompany(_client);
-            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", signInObject.Token);
-            await TestHelper.Instance.GenerateProject(_client, _companyRepository);
-            await TestHelper.Instance.GenerateIssue(_client, _companyRepository, _projectRepository, _userRepository);
+            await TestHelper.Instance.GenerateAll(_client);
         }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
@@ -24,12 +24,6 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             _client = factory.CreateClient();
         }
 
-        [OneTimeTearDown]
-        public async Task OneTimeTearDown()
-        {
-            await Clear();
-        }
-
         [SetUp]
         public async Task Setup()
         {

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
@@ -1,7 +1,7 @@
 ﻿using Goose.API;
 using Goose.API.Repositories;
 using Goose.Domain.Models.Auth;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
@@ -60,7 +60,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task CreateSummary()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            var issue = await TestHelper.Instance.GetIssueAsync();
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
             await _issueRequirementService.CreateAsync(issue.Id, issueRequirement);
 
@@ -85,7 +85,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task CreateSummaryFalse()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            var issue = await TestHelper.Instance.GetIssueAsync();
 
             var uri = $"/api/issues/{issue.Id}/summaries";
             var responce = await _client.PostAsync(uri, new object().ToStringContent());
@@ -99,7 +99,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task AcceptSummary()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            var issue = await TestHelper.Instance.GetIssueAsync();
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
             await _issueRequirementService.CreateAsync(issue.Id, issueRequirement);
 
@@ -111,7 +111,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             responce = await _client.PutAsync(uri, new object().ToStringContent());
             Assert.IsTrue(responce.IsSuccessStatusCode);
 
-            issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            issue = await TestHelper.Instance.GetIssueAsync();
             Assert.IsTrue(issue.IssueDetail.RequirementsAccepted);
 
             var state = await TestHelper.Instance.GetStateByName(_client, issue.ProjectId.ToString(), State.WaitingState);
@@ -126,7 +126,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task AcceptSummaryFalse()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            var issue = await TestHelper.Instance.GetIssueAsync();
             var uri = $"/api/issues/{issue.Id}/summaries?accept=true";
             var responce = await _client.PutAsync(uri, new object().ToStringContent());
             Assert.IsFalse(responce.IsSuccessStatusCode);
@@ -135,7 +135,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task DeclineSummary()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            var issue = await TestHelper.Instance.GetIssueAsync();
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
             await _issueRequirementService.CreateAsync(issue.Id, issueRequirement);
 
@@ -147,7 +147,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             responce = await _client.PutAsync(uri, new object().ToStringContent());
             Assert.IsTrue(responce.IsSuccessStatusCode);
 
-            issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            issue = await TestHelper.Instance.GetIssueAsync();
             Assert.IsFalse(issue.IssueDetail.RequirementsAccepted);
             Assert.IsFalse(issue.IssueDetail.RequirementsSummaryCreated);
 
@@ -160,8 +160,8 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task DeclineSummaryFalse()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
-           
+            var issue = await TestHelper.Instance.GetIssueAsync();
+
             var uri = $"/api/issues/{issue.Id}/summaries?accept=false";
             var responce = await _client.PutAsync(uri, new object().ToStringContent());
             Assert.IsFalse(responce.IsSuccessStatusCode);
@@ -175,7 +175,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         [Test]
         public async Task DeclineSummaryFalse2()
         {
-            var issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            var issue = await TestHelper.Instance.GetIssueAsync();
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
             await _issueRequirementService.CreateAsync(issue.Id, issueRequirement);
 
@@ -187,7 +187,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             responce = await _client.PutAsync(uri, new object().ToStringContent());
             Assert.IsTrue(responce.IsSuccessStatusCode);
 
-            issue = (await _issueRepository.FilterByAsync(x => x.IssueDetail.Name.Equals(TestHelper.TicketName))).FirstOrDefault();
+            issue = await TestHelper.Instance.GetIssueAsync();
             Assert.IsTrue(issue.IssueDetail.RequirementsAccepted);
 
             var state = await TestHelper.Instance.GetStateByName(_client, issue.ProjectId.ToString(), State.WaitingState);
@@ -200,17 +200,12 @@ namespace Goose.Tests.Application.IntegrationTests.issues
 
         private async Task Clear()
         {
-            await TestHelper.Instance.ClearCompany(_companyRepository, _userRepository);
-            await TestHelper.Instance.ClearProject(_projectRepository);
-            await TestHelper.Instance.ClearIssue(_issueRepository);
+            await TestHelper.Instance.ClearAll();
         }
 
         private async Task Generate()
         {
-            signInObject = await TestHelper.Instance.GenerateCompany(_client);
-            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", signInObject.Token);
-            await TestHelper.Instance.GenerateProject(_client, _companyRepository);
-            await TestHelper.Instance.GenerateIssue(_client, _companyRepository, _projectRepository, _userRepository);
+            await TestHelper.Instance.GenerateAll(_client);
         }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
@@ -3,7 +3,7 @@ using Goose.API.Repositories;
 using Goose.API.Services.Issues;
 using Goose.Domain.Models.Auth;
 using Goose.Domain.Models.Projects;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
@@ -20,13 +20,17 @@ namespace Goose.Tests.Application.IntegrationTests.issues
     {
         private HttpClient _client;
         private IIssueRequirementService _issueRequirementService;
-        private SignInResponse signInObject;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
             var factory = new WebApplicationFactory<Startup>();
             _client = factory.CreateClient();
+
+            var scopeFactory = factory.Server.Services.GetService<IServiceScopeFactory>();
+
+            using var scope = scopeFactory.CreateScope();
+            _issueRequirementService = scope.ServiceProvider.GetService<IIssueRequirementService>();
         }
 
         [SetUp]

--- a/Goose.Tests/Application.IntegrationTests/issues/IssuesControllerTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssuesControllerTests.cs
@@ -7,7 +7,7 @@ using Goose.API;
 using Goose.Domain.DTOs;
 using Goose.Domain.DTOs.Issues;
 using Goose.Domain.Models.Companies;
-using Goose.Domain.Models.Tickets;
+using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Mvc.Testing;
 using MongoDB.Bson;
 using NUnit.Framework;


### PR DESCRIPTION
closes #43 
Enthält Integrationstests für alle Arten, auf die ein ConversationItem erstellt werden kann.

Ausserdem enthält der PR
- Bugfix für die Predecessor-Endpunkte
- TestHelper unterstützt nun das Erstellen mehrere Issues (Gut zum Testen von Corgängern/Nachfolgen oder Untertickets)
- Mehr Hilfsmethoden für TestHelper
  - Getter für Project, Issue, usw
  - GenerateAll und ClearAll Methoden
  - Die alten Tests wurden angepasst, sodass sie auch diese Methoden verwenden