### PR TITLE
feature/better_conversation_data

### DIFF
--- a/Goose.API/Controllers/ConversationController.cs
+++ b/Goose.API/Controllers/ConversationController.cs
@@ -5,6 +5,7 @@ using Goose.Domain.DTOs.Issues;
 using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Goose.API.Controllers
@@ -24,7 +25,7 @@ namespace Goose.API.Controllers
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> Get([FromRoute] string issueId)
+        public async Task<ActionResult<IList<IssueConversationDTO>>> Get([FromRoute] string issueId)
         {
             var issueConversations = await _issueConversationService.GetConversationsFromIssueAsync(issueId);
             return Ok(issueConversations);
@@ -34,7 +35,7 @@ namespace Goose.API.Controllers
         [HttpGet("{id}", Name = nameof(GetById))]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> GetById([FromRoute] string issueId, string id)
+        public async Task<ActionResult<IssueConversationDTO>> GetById([FromRoute] string issueId, string id)
         {
             var issueConversation = await _issueConversationService.GetConversationFromIssueAsync(issueId, id);
             return Ok(issueConversation);

--- a/Goose.API/Services/issues/IssuePredecessorService.cs
+++ b/Goose.API/Services/issues/IssuePredecessorService.cs
@@ -60,7 +60,8 @@ namespace Goose.API.Services.Issues
                 Id = ObjectId.GenerateNewId(),
                 CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.PredecessorAddedType,
-                Data = $"{predecessorId}",
+                Data = null,
+                OtherTicketId = predecessorId,
             });
 
             await Task.WhenAll(_issueRepo.UpdateAsync(successor), _issueRepo.UpdateAsync(predecessor));
@@ -79,7 +80,8 @@ namespace Goose.API.Services.Issues
                     Id = ObjectId.GenerateNewId(),
                     CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                     Type = IssueConversation.PredecessorRemovedType,
-                    Data = $"{predecessorId}",
+                    Data = null,
+                    OtherTicketId = predecessorId,
                 });
 
                 await Task.WhenAll(_issueRepo.UpdateAsync(successor), _issueRepo.UpdateAsync(predecessor));

--- a/Goose.API/Services/issues/IssueService.cs
+++ b/Goose.API/Services/issues/IssueService.cs
@@ -207,7 +207,8 @@ namespace Goose.API.Services.Issues
                 Id = ObjectId.GenerateNewId(),
                 CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                 Type = IssueConversation.ChildIssueAddedType,
-                Data = $"{issueId}",
+                Data = null,
+                OtherTicketId = issueId,
             });
             await _issueRepo.UpdateAsync(parent);
         }
@@ -228,7 +229,8 @@ namespace Goose.API.Services.Issues
                     Id = ObjectId.GenerateNewId(),
                     CreatorUserId = _httpContextAccessor.HttpContext.User.GetUserId(),
                     Type = IssueConversation.ChildIssueRemovedType,
-                    Data = $"{issueId}",
+                    Data = null,
+                    OtherTicketId = issueId,
                 });
                 await _issueRepo.UpdateAsync(parent);
             }

--- a/Goose.Domain/DTOs/Issues/IssueConversationDTO.cs
+++ b/Goose.Domain/DTOs/Issues/IssueConversationDTO.cs
@@ -11,6 +11,7 @@ namespace Goose.Domain.DTOs.Issues
         public UserDTO Creator { get; set; }
         public string Type { get; set; }
         public string Data { get; set; }
+        public ObjectId? OtherTicketId { get; set; }
         public IList<string> Requirements { get; set; }
         public DateTime CreatedAt { get; set; }
 
@@ -22,6 +23,7 @@ namespace Goose.Domain.DTOs.Issues
             Creator = creator;
             Type = issueConversation.Type;
             Data = issueConversation.Data;
+            OtherTicketId = issueConversation.OtherTicketId;
             Requirements = issueConversation.Requirements;
             CreatedAt = issueConversation.CreatedAt;
         }

--- a/Goose.Domain/Models/tickets/IssueConversation.cs
+++ b/Goose.Domain/Models/tickets/IssueConversation.cs
@@ -4,15 +4,18 @@ using Goose.Domain.Models.Identity;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
+
 namespace Goose.Domain.Models.Issues
 {
     public class IssueConversation
     {
         [BsonId]
         public ObjectId Id { get; set; }
-        public ObjectId? CreatorUserId { get; set; }
+        public ObjectId CreatorUserId { get; set; }
         public string Type { get; set; }
         public string Data { get; set; }
+        // This field is used to store a reference to the added/removed predecessor/child
+        public ObjectId? OtherTicketId { get; set; }
         public IList<string> Requirements { get; set; }
 
         public DateTime CreatedAt { get => Id.CreationTime; }

--- a/Goose.Tests/Application.IntegrationTests/TestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/TestHelper.cs
@@ -230,6 +230,22 @@ namespace Goose.Tests.Application.IntegrationTests
             return issues.FirstOrDefault();
         }
 
+        /// <summary>
+        /// Retrieves an issue through the Rest-api. Useful for testing the api from end to end
+        /// </summary>
+        /// <param name="_client"></param>
+        /// <param name="issueIndex"></param>
+        /// <returns></returns>
+        public async Task<IssueDTODetailed> GetIssueThroughClientAsync(HttpClient _client, int issueIndex = 0)
+        {
+            var project = await GetProject();
+            var issueId = _testIssues[issueIndex];
+            var uri = $"api/projects/{project.Id}/issues/{issueId}?GetAll=true";
+
+            var result = await _client.GetAsync(uri);
+            return await result.Content.Parse<IssueDTODetailed>();
+        }
+
         public async Task<User> GetUser()
         {
             var company = await GetCompany();

--- a/Goose.Tests/Application.IntegrationTests/TestUtil.cs
+++ b/Goose.Tests/Application.IntegrationTests/TestUtil.cs
@@ -42,7 +42,7 @@ namespace Goose.Tests.Application.IntegrationTests
 
         public override bool CanConvert(Type objectType)
         {
-            return typeof(ObjectId).IsAssignableFrom(objectType);
+            return typeof(ObjectId?).IsAssignableFrom(objectType);
         }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
@@ -104,27 +104,30 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var user = await TestHelper.Instance.GetUser();
 
             var issue = await TestHelper.Instance.GetIssueAsync();
+            var otherIssue = await TestHelper.Instance.GetIssueAsync(1);
             var uri = $"/api/issues/{issue.Id}/predecessors/{predecessorIssue.Id}";
 
             // Add the predecessor
             var response = await _client.PutAsync(uri, null);
             Assert.IsTrue(response.IsSuccessStatusCode);
 
-            issue = await TestHelper.Instance.GetIssueAsync();
-            var latestConversationItem = issue.ConversationItems.Last();
-            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            var issueDTO = await TestHelper.Instance.GetIssueThroughClientAsync(_client);
+            var latestConversationItem = issueDTO.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.Creator.Id, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.PredecessorAddedType);
-            Assert.AreEqual(latestConversationItem.Data, predecessorIssue.Id.ToString());
+            Assert.AreEqual(latestConversationItem.OtherTicketId, predecessorIssue.Id);
+            Assert.IsTrue(latestConversationItem.Data.Contains(otherIssue.IssueDetail.Name));
 
             // Remove the predecessor
             response = await _client.DeleteAsync(uri);
             Assert.IsTrue(response.IsSuccessStatusCode);
 
-            issue = await TestHelper.Instance.GetIssueAsync();
-            latestConversationItem = issue.ConversationItems.Last();
-            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            issueDTO = await TestHelper.Instance.GetIssueThroughClientAsync(_client);
+            latestConversationItem = issueDTO.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.Creator.Id, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.PredecessorRemovedType);
-            Assert.AreEqual(latestConversationItem.Data, predecessorIssue.Id.ToString());
+            Assert.AreEqual(latestConversationItem.OtherTicketId, predecessorIssue.Id);
+            Assert.IsTrue(latestConversationItem.Data.Contains(otherIssue.IssueDetail.Name));
         }
 
         [Test]
@@ -143,21 +146,23 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var response = await _client.PutAsync(addUri, null);
             Assert.IsTrue(response.IsSuccessStatusCode);
 
-            issue = await TestHelper.Instance.GetIssueAsync();
-            var latestConversationItem = issue.ConversationItems.Last();
-            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            var issueDTO = await TestHelper.Instance.GetIssueThroughClientAsync(_client);
+            var latestConversationItem = issueDTO.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.Creator.Id, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.ChildIssueAddedType);
-            Assert.AreEqual(latestConversationItem.Data, childIssue.Id.ToString());
+            Assert.AreEqual(latestConversationItem.OtherTicketId, childIssue.Id);
+            Assert.IsTrue(latestConversationItem.Data.Contains(childIssue.IssueDetail.Name));
 
             // Remove the parent
             response = await _client.DeleteAsync(removeUri);
             Assert.IsTrue(response.IsSuccessStatusCode);
 
-            issue = await TestHelper.Instance.GetIssueAsync();
-            latestConversationItem = issue.ConversationItems.Last();
-            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
+            issueDTO = await TestHelper.Instance.GetIssueThroughClientAsync(_client);
+            latestConversationItem = issueDTO.ConversationItems.Last();
+            Assert.AreEqual(latestConversationItem.Creator.Id, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.ChildIssueRemovedType);
-            Assert.AreEqual(latestConversationItem.Data, childIssue.Id.ToString());
+            Assert.AreEqual(latestConversationItem.OtherTicketId, childIssue.Id);
+            Assert.IsTrue(latestConversationItem.Data.Contains(childIssue.IssueDetail.Name));
         }
 
         [Test]


### PR DESCRIPTION
Noch eine Anpassung zur IssueConversation
Auch bei Vorgängern und Untertickets wird in Data jetzt immer ein anzeigbarer String verschickt. Das sollte dem Frontend die Arbeit erleichtern. Die Id des Tickets wird nun in einem neuen Feld "otherTIcketId" verschickt, sodass nach wie vor auf das andere Ticket verlinkt werden kann.