### PR TITLE
added missing apicontroller attributes

### DIFF
--- a/Goose.API/Controllers/ProjectController.cs
+++ b/Goose.API/Controllers/ProjectController.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 namespace Goose.API.Controllers
 {
     [Route("api/companies/{companyId}/projects")]
+    [ApiController]
     public class ProjectController : ControllerBase
     {
         private readonly IProjectService _projectService;

--- a/Goose.API/Controllers/ProjectUserController.cs
+++ b/Goose.API/Controllers/ProjectUserController.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 namespace Goose.API.Controllers
 {
     [Route("api/projects/{projectId}/users")]
+    [ApiController]
     public class ProjectUserController : ControllerBase
     {
         private readonly IProjectUserService _projectUserService;

--- a/Goose.API/Controllers/StateController.cs
+++ b/Goose.API/Controllers/StateController.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 namespace Goose.API.Controllers
 {
     [Route("api/projects/{projectId}/states")]
+    [ApiController]
     public class StateController : ControllerBase
     {
         private readonly IStateService _stateService;


### PR DESCRIPTION
Wenn die Attribute nicht vorhanden sind, werden ungültige Übergebene Werte ignoriert und durch default-Werte ersetzt.