### PR TITLE
Hotfix/create project user

### DIFF
--- a/Goose.API/Controllers/ProjectUserController.cs
+++ b/Goose.API/Controllers/ProjectUserController.cs
@@ -28,18 +28,18 @@ namespace Goose.API.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<PropertyUserDTO>> UpdateProjectUser([FromBody] PropertyUserDTO projectUserDTO, [FromRoute] ObjectId projectId, ObjectId userId)
+        public async Task<ActionResult<IList<PropertyUserDTO>>> UpdateProjectUser([FromBody] PropertyUserDTO projectUserDTO, [FromRoute] ObjectId projectId, ObjectId userId)
         {
-           var user =  await _projectUserService.UpdateProjectUser(projectId, userId, projectUserDTO);
+           var users =  await _projectUserService.UpdateProjectUser(projectId, userId, projectUserDTO);
 
-            return Ok(user);
+            return Ok(users);
         }
 
         // GET: api/projects/{projectId}/users/
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult<IList<ProjectDTO>>> GetProjectUsers([FromRoute] ObjectId projectId)
+        public async Task<ActionResult<IList<PropertyUserDTO>>> GetProjectUsers([FromRoute] ObjectId projectId)
         {
             var projectIter = await _projectUserService.GetProjectUsers(projectId);
             return Ok(projectIter);
@@ -50,7 +50,7 @@ namespace Goose.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult<ProjectDTO>> GetProjectUser([FromRoute] ObjectId projectId, ObjectId userId)
+        public async Task<ActionResult<PropertyUserDTO>> GetProjectUser([FromRoute] ObjectId projectId, ObjectId userId)
         {
             var projectUser = await _projectUserService.GetProjectUser(projectId, userId);
 

--- a/Goose.API/Controllers/ProjectUserController.cs
+++ b/Goose.API/Controllers/ProjectUserController.cs
@@ -28,11 +28,11 @@ namespace Goose.API.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult> UpdateProjectUser([FromBody] PropertyUserDTO projectUserDTO, [FromRoute] ObjectId projectId, ObjectId userId)
+        public async Task<ActionResult<PropertyUserDTO>> UpdateProjectUser([FromBody] PropertyUserDTO projectUserDTO, [FromRoute] ObjectId projectId, ObjectId userId)
         {
-            await _projectUserService.UpdateProjectUser(projectId, userId, projectUserDTO);
+           var user =  await _projectUserService.UpdateProjectUser(projectId, userId, projectUserDTO);
 
-            return NoContent();
+            return Ok(user);
         }
 
         // GET: api/projects/{projectId}/users/

--- a/Goose.API/Goose.API.csproj
+++ b/Goose.API/Goose.API.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
   </ItemGroup>

--- a/Goose.API/Services/IssueConversationService.cs
+++ b/Goose.API/Services/IssueConversationService.cs
@@ -205,7 +205,8 @@ namespace Goose.API.Services
             {
                 { ProjectRolesRequirement.EmployeeRequirement, "You need to be the employee with write-rights in this project, in order to write a conversation." },
                 { ProjectRolesRequirement.LeaderRequirement, "You need to be the leader in this project, in order to write a conversation." },
-                { ProjectRolesRequirement.CustomerRequirement, "You need to be the customer of this project, in order to write a conversation." }
+                { ProjectRolesRequirement.CustomerRequirement, "You need to be the customer of this project, in order to write a conversation." },
+                { CompanyRolesRequirement.CompanyOwner, "You need to be the ComponyOwner of the Company, in order to write a conversation to this Project" }
             };
 
             // validate requirements with the appropriate handlers.
@@ -221,10 +222,11 @@ namespace Goose.API.Services
 
             Dictionary<IAuthorizationRequirement, string> requirementsWithErrors = new()
             {
-                { ProjectRolesRequirement.ReadonlyEmployeeRequirement, "You need to be the employee with read-rights in this project, in order to write a conversation." },
-                { ProjectRolesRequirement.EmployeeRequirement, "You need to be the employee with write-rights in this project, in order to write a conversation." },
-                { ProjectRolesRequirement.LeaderRequirement, "You need to be the leader in this project, in order to write a conversation." },
-                { ProjectRolesRequirement.CustomerRequirement, "You need to be the customer of this project, in order to write a conversation." }
+                { ProjectRolesRequirement.ReadonlyEmployeeRequirement, "You need to be the employee with read-rights in this project, in order to see a conversation." },
+                { ProjectRolesRequirement.EmployeeRequirement, "You need to be the employee with write-rights in this project, in order to see a conversation." },
+                { ProjectRolesRequirement.LeaderRequirement, "You need to be the leader in this project, in order to see a conversation." },
+                { ProjectRolesRequirement.CustomerRequirement, "You need to be the customer of this project, in order to see a conversation." },
+                { CompanyRolesRequirement.CompanyOwner, "You need to be the ComponyOwner of the Company, in order to see a conversation to this Project" }
             };
 
             // validate requirements with the appropriate handlers.

--- a/Goose.API/Services/ProjectUserService.cs
+++ b/Goose.API/Services/ProjectUserService.cs
@@ -148,11 +148,18 @@ namespace Goose.API.Services
 
             using (var rw = new ReaderWriterLockSlim())
             {
-                rw.EnterWriteLock();
-                existingProject.Users.Add(newProjectUser);
+                try
+                {
+                    rw.EnterWriteLock();
+                    existingProject.Users.Add(newProjectUser);
 
-                await _projectRepository.UpdateAsync(existingProject);
-                rw.ExitWriteLock();
+                    await _projectRepository.UpdateAsync(existingProject);
+                }
+                finally
+                {
+                    rw.ExitWriteLock();
+                }
+                
             }
 
             return await GetProjectUsers(projectId);

--- a/Goose.API/Services/ProjectUserService.cs
+++ b/Goose.API/Services/ProjectUserService.cs
@@ -16,7 +16,7 @@ namespace Goose.API.Services
     {
         Task<IList<PropertyUserDTO>> GetProjectUsers(ObjectId projectId);
         Task<PropertyUserDTO> GetProjectUser(ObjectId projectId, ObjectId userId);
-        Task<PropertyUserDTO> UpdateProjectUser(ObjectId projectId, ObjectId userId, PropertyUserDTO projectUserDTO);
+        Task<IList<PropertyUserDTO>> UpdateProjectUser(ObjectId projectId, ObjectId userId, PropertyUserDTO projectUserDTO);
         Task RemoveUserFromProject(ObjectId projectId, ObjectId userId);
     }
 
@@ -100,7 +100,7 @@ namespace Goose.API.Services
             return userDTOs.ToList();
         }
 
-        public async Task<PropertyUserDTO> UpdateProjectUser(ObjectId projectId, ObjectId userId, PropertyUserDTO projectUserDTO)
+        public async Task<IList<PropertyUserDTO>> UpdateProjectUser(ObjectId projectId, ObjectId userId, PropertyUserDTO projectUserDTO)
         {
             if (userId != projectUserDTO.User.Id)
             {
@@ -149,16 +149,7 @@ namespace Goose.API.Services
 
             await _projectRepository.UpdateAsync(existingProject);
 
-            var project = await _projectRepository.GetAsync(projectId);
-
-            var list = project.Users;
-
-            var user = list.FirstOrDefault(x => x.UserId.Equals(userId));
-
-            if (user is null)
-                throw new HttpStatusException(400, "Etwas ist schief gelaufen");
-
-            return new PropertyUserDTO() { User = new UserDTO(await _userRepository.GetAsync(userId)), Roles = rolen };
+            return await GetProjectUsers(projectId);
         }
 
         public async Task RemoveUserFromProject(ObjectId projectId, ObjectId userId)

--- a/Goose.API/Services/ProjectUserService.cs
+++ b/Goose.API/Services/ProjectUserService.cs
@@ -149,7 +149,9 @@ namespace Goose.API.Services
 
             await _projectRepository.UpdateAsync(existingProject);
 
-            var list = existingProject.Users;
+            var project = await _projectRepository.GetAsync(projectId);
+
+            var list = project.Users;
 
             var user = list.FirstOrDefault(x => x.UserId.Equals(userId));
 

--- a/Goose.API/Services/ProjectUserService.cs
+++ b/Goose.API/Services/ProjectUserService.cs
@@ -124,15 +124,15 @@ namespace Goose.API.Services
                 RoleIds = roleIds.ToList(),
             };
 
-            var existingProject = await _projectRepository.GetAsync(projectId);
-
-            if (existingProject == null)
-            {
-                throw new HttpStatusException(404, "Invalid projectId");
-            }
-
             using (await _mutex.LockAsync())
             {
+                var existingProject = await _projectRepository.GetAsync(projectId);
+
+                if (existingProject == null)
+                {
+                    throw new HttpStatusException(404, "Invalid projectId");
+                }
+
                 var projectLeaderRole = (await _roleRepository.FilterByAsync(x => x.Name == Role.ProjectLeaderRole)).SingleOrDefault();
 
                 if (projectLeaderRole != null && roleIds.Contains(projectLeaderRole.Id))

--- a/Goose.API/Services/ProjectUserService.cs
+++ b/Goose.API/Services/ProjectUserService.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Goose.API.Utils;
 using Goose.API.Utils.Exceptions;
 using Goose.Domain.Models.Identity;
+using System.Threading;
 
 namespace Goose.API.Services
 {
@@ -145,9 +146,14 @@ namespace Goose.API.Services
                 }
             }
 
-            existingProject.Users.Add(newProjectUser);
+            using (var rw = new ReaderWriterLockSlim())
+            {
+                rw.EnterWriteLock();
+                existingProject.Users.Add(newProjectUser);
 
-            await _projectRepository.UpdateAsync(existingProject);
+                await _projectRepository.UpdateAsync(existingProject);
+                rw.ExitWriteLock();
+            }
 
             return await GetProjectUsers(projectId);
         }

--- a/Goose.API/Services/issues/IssueService.cs
+++ b/Goose.API/Services/issues/IssueService.cs
@@ -119,6 +119,8 @@ namespace Goose.API.Services.Issues
             //TODO more validation
             detail.Requirements = new List<IssueRequirement>();
             detail.RelevantDocuments = new List<string>();
+            detail.RequirementsSummaryCreated = false;
+            detail.RequirementsAccepted = false;
             return detail;
         }
 

--- a/Goose.API/Services/issues/IssueService.cs
+++ b/Goose.API/Services/issues/IssueService.cs
@@ -305,7 +305,8 @@ namespace Goose.API.Services.Issues
             {
                 ProjectRolesRequirement.EmployeeRequirement,
                 ProjectRolesRequirement.LeaderRequirement,
-                ProjectRolesRequirement.ReadonlyEmployeeRequirement
+                ProjectRolesRequirement.ReadonlyEmployeeRequirement,
+                CompanyRolesRequirement.CompanyOwner
             };
             
 
@@ -321,7 +322,8 @@ namespace Goose.API.Services.Issues
             Dictionary<IAuthorizationRequirement, string> requirementsWithErrors = new()
             {
                 { ProjectRolesRequirement.EmployeeRequirement, "You need to be the employee with write-rights in this project, in order to change the state" },
-                { ProjectRolesRequirement.LeaderRequirement, "You need to be the leader in this project, in order to change the state." },                
+                { ProjectRolesRequirement.LeaderRequirement, "You need to be the leader in this project, in order to change the state." },
+                { CompanyRolesRequirement.CompanyOwner, "You need to be a Owner of the Company, in order to change the state" }
             };
 
             // validate requirements with the appropriate handlers.
@@ -337,6 +339,7 @@ namespace Goose.API.Services.Issues
                 { ProjectRolesRequirement.EmployeeRequirement, "You need to be the employee with write-rights in this project, in order to create or update a issue." },
                 { ProjectRolesRequirement.LeaderRequirement, "You need to be the leader in this project, in order to create or update a issue." },
                 { ProjectRolesRequirement.CustomerRequirement, "You need to be a customer in this project, in order to create or update a issue." },
+                { CompanyRolesRequirement.CompanyOwner, "You need to be a Owner of the Company, in order to create or update a issue"}
             };
 
             // validate requirements with the appropriate handlers.

--- a/Goose.API/Startup.cs
+++ b/Goose.API/Startup.cs
@@ -153,33 +153,33 @@ namespace Goose.API
             services.AddAutoMapper(typeof(AutoMapping));
             
             services.AddSingleton<IDbContext, DbContext>();
-            services.AddScoped<IAuthorizationHandler, CompanyRoleHandler>();
-            services.AddScoped<IAuthorizationHandler, ProjectRoleHandler>();
+            services.AddSingleton<IAuthorizationHandler, CompanyRoleHandler>();
+            services.AddSingleton<IAuthorizationHandler, ProjectRoleHandler>();
 
-            services.AddScoped<IIssueRepository, IssueRepository>();
-            services.AddScoped<IUserRepository, UserRepository>();
-            services.AddScoped<IRoleRepository, RoleRepository>();
-            services.AddScoped<IProjectRepository, ProjectRepository>();
-            services.AddScoped<ICompanyRepository, CompanyRepository>();
+            services.AddSingleton<IIssueRepository, IssueRepository>();
+            services.AddSingleton<IUserRepository, UserRepository>();
+            services.AddSingleton<IRoleRepository, RoleRepository>();
+            services.AddSingleton<IProjectRepository, ProjectRepository>();
+            services.AddSingleton<ICompanyRepository, CompanyRepository>();
 
-            services.AddScoped<IIssueService, IssueService>();
-            services.AddScoped<IIssueDetailedService, IssueDetailedService>();
-            services.AddScoped<IIssueConversationService, IssueConversationService>();
-            services.AddScoped<IIssueAssignedUserService, IssueAssignedUserService>();
-            services.AddScoped<IIssueRequirementService, IssueRequirementService>();
-            services.AddScoped<IIssueRequestValidator, IssueRequestValidator>();
-            services.AddScoped<IIssuePredecessorService, IssuePredecessorService>();
-            services.AddScoped<IIssuePredecessorService, IssuePredecessorService>();
-            services.AddScoped<IIssueTimeSheetService, IssueTimeSheetService>(); 
-            services.AddScoped<IUserService, UserService>();     
-            services.AddScoped<IRoleService, RoleService>();    
-            services.AddScoped<IProjectService, ProjectService>();
-            services.AddScoped<IProjectUserService, ProjectUserService>();
-            services.AddScoped<IStateService, StateService>();
-            services.AddScoped<ICompanyService, CompanyService>();
-            services.AddScoped<IAuthService, AuthService>();
-            services.AddScoped<ICompanyUserService, CompanyUserService>();
-            services.AddScoped<IIssueSummaryService, IssueSummaryService>();
+            services.AddSingleton<IIssueService, IssueService>();
+            services.AddSingleton<IIssueDetailedService, IssueDetailedService>();
+            services.AddSingleton<IIssueConversationService, IssueConversationService>();
+            services.AddSingleton<IIssueAssignedUserService, IssueAssignedUserService>();
+            services.AddSingleton<IIssueRequirementService, IssueRequirementService>();
+            services.AddSingleton<IIssueRequestValidator, IssueRequestValidator>();
+            services.AddSingleton<IIssuePredecessorService, IssuePredecessorService>();
+            services.AddSingleton<IIssuePredecessorService, IssuePredecessorService>();
+            services.AddSingleton<IIssueTimeSheetService, IssueTimeSheetService>(); 
+            services.AddSingleton<IUserService, UserService>();     
+            services.AddSingleton<IRoleService, RoleService>();    
+            services.AddSingleton<IProjectService, ProjectService>();
+            services.AddSingleton<IProjectUserService, ProjectUserService>();
+            services.AddSingleton<IStateService, StateService>();
+            services.AddSingleton<ICompanyService, CompanyService>();
+            services.AddSingleton<IAuthService, AuthService>();
+            services.AddSingleton<ICompanyUserService, CompanyUserService>();
+            services.AddSingleton<IIssueSummaryService, IssueSummaryService>();
 
             services.AddHttpContextAccessor();
         }

--- a/Goose.Tests/Application.IntegrationTests/TestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/TestHelper.cs
@@ -167,9 +167,9 @@ namespace Goose.Tests.Application.IntegrationTests
                     Progress = 0,
                     Description = null,
                     Requirements = null,
-                    RequirementsAccepted = false,
-                    RequirementsSummaryCreated = false,
-                    RequirementsNeeded = false,
+                    RequirementsAccepted = true,
+                    RequirementsSummaryCreated = true,
+                    RequirementsNeeded = true,
                     Priority = 0,
                     Visibility = false,
                     RelevantDocuments = null


### PR DESCRIPTION
Wir hatten ein Problem mit der Asynchronität als 2 User dem gleichen Projekt zur gleichen zeit hinzugefügt wurden.
Wir haben nun alle Services von AddScoped zu AddSingleton geändert und ein Package heruntergeladen um eine asynchrone Methode zu locken.
Der Lock ist momentan nur in Project User bei der Update Methode.
Es ist vielleicht nicht die beste Lösung und ich bin offen für andere Lösungen.
Jedensfalls müssen wir unser System Thread safe machen!