### PR TITLE
Feature/timesheet logic and auth

### DIFF
--- a/Goose.API/Authorization/Handlers/IssueOperationAuthorizationHandler.cs
+++ b/Goose.API/Authorization/Handlers/IssueOperationAuthorizationHandler.cs
@@ -94,6 +94,10 @@ namespace Goose.API.Authorization.Handlers
                     x => x.Contains(Role.ProjectLeaderRole.Id) || x.Contains(Role.CompanyRole.Id)
                 },
                 {
+                    IssueOperationRequirments.ReadTimeSheets,
+                    x => x.Contains(Role.EmployeeRole.Id) || x.Contains(Role.ReadonlyEmployeeRole.Id) || x.Contains(Role.ProjectLeaderRole.Id) || x.Contains(Role.CompanyRole.Id)
+                },
+                {
                     IssueOperationRequirments.EditAllTimeSheets,
                     x => x.Contains(Role.ProjectLeaderRole.Id) || x.Contains(Role.CompanyRole.Id)
                 },
@@ -143,6 +147,10 @@ namespace Goose.API.Authorization.Handlers
                     x => x.Contains(Role.ProjectLeaderRole.Id) || x.Contains(Role.CompanyRole.Id)
                 },
                 {
+                    IssueOperationRequirments.ReadTimeSheets,
+                    x => x.Contains(Role.EmployeeRole.Id) || x.Contains(Role.ReadonlyEmployeeRole.Id) || x.Contains(Role.ProjectLeaderRole.Id) || x.Contains(Role.CompanyRole.Id)
+                },
+                {
                     IssueOperationRequirments.EditOwnTimeSheets,
                     x => x.Contains(Role.EmployeeRole.Id) || x.Contains(Role.ProjectLeaderRole.Id) || x.Contains(Role.CompanyRole.Id)
                 },
@@ -179,6 +187,10 @@ namespace Goose.API.Authorization.Handlers
                 {
                     IssueOperationRequirments.EditStateOfInternal,
                     x => x.Contains(Role.ProjectLeaderRole.Id) || x.Contains(Role.CompanyRole.Id)
+                },
+                {
+                    IssueOperationRequirments.ReadTimeSheets,
+                    x => x.Contains(Role.EmployeeRole.Id) || x.Contains(Role.ReadonlyEmployeeRole.Id) || x.Contains(Role.ProjectLeaderRole.Id) || x.Contains(Role.CompanyRole.Id)
                 },
                 {
                     IssueOperationRequirments.EditOwnTimeSheets,

--- a/Goose.API/Authorization/Requirements/IssueOperationRequirment.cs
+++ b/Goose.API/Authorization/Requirements/IssueOperationRequirment.cs
@@ -16,6 +16,7 @@ namespace Goose.API.Authorization.Requirements
         public readonly static OperationAuthorizationRequirement DiscardTicket = new() { Name = nameof(DiscardTicket) };
         public readonly static OperationAuthorizationRequirement EditState = new() { Name = nameof(EditState) };
         public readonly static OperationAuthorizationRequirement EditStateOfInternal = new() { Name = nameof(EditStateOfInternal) };
+        public readonly static OperationAuthorizationRequirement ReadTimeSheets = new() { Name = nameof(ReadTimeSheets) };
         public readonly static OperationAuthorizationRequirement CreateOwnTimeSheets = new() { Name = nameof(CreateOwnTimeSheets) };
         public readonly static OperationAuthorizationRequirement EditOwnTimeSheets = new() { Name = nameof(EditOwnTimeSheets) };
         public readonly static OperationAuthorizationRequirement EditAllTimeSheets = new() { Name = nameof(EditAllTimeSheets) };

--- a/Goose.API/Repositories/IssueRepository.cs
+++ b/Goose.API/Repositories/IssueRepository.cs
@@ -9,7 +9,6 @@ using MongoDB.Driver;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System;
 
 namespace Goose.API.Repositories
 {

--- a/Goose.API/Services/issues/IssueTimeSheetService.cs
+++ b/Goose.API/Services/issues/IssueTimeSheetService.cs
@@ -100,6 +100,17 @@ namespace Goose.API.Services.Issues
             await CreateTimeExccededMessage(issueId, timeSheetDto);
         }
 
+        private async Task CanUserReadTimeSheetsAsync(Issue issue)
+        {
+            var requirementsWithErrors = new Dictionary<IAuthorizationRequirement, string>()
+            {
+                { IssueOperationRequirments.ReadTimeSheets, "You are not allowed to read timesheets" }
+            };
+
+            var authorizationResult = await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, issue, requirementsWithErrors.Keys);
+            authorizationResult.ThrowErrorForFailedRequirements(requirementsWithErrors);
+        }
+
         private async Task CanUserUpdateTimeSheetAsync(Issue issue)
         {
             Dictionary<IAuthorizationRequirement, string> requirementsWithErrors = new()
@@ -138,7 +149,7 @@ namespace Goose.API.Services.Issues
 
         private async Task CreateTimeExccededMessage(ObjectId issueId, IssueTimeSheetDTO timeSheetDto)
         {
-            if (timeSheetDto.End == default(DateTime))
+            if (timeSheetDto.End == default)
                 return;
 
             var updatedIssue = await _issueRepo.GetAsync(issueId);

--- a/Goose.API/Services/issues/IssueTimeSheetService.cs
+++ b/Goose.API/Services/issues/IssueTimeSheetService.cs
@@ -52,13 +52,21 @@ namespace Goose.API.Services.Issues
 
         public async Task<IList<IssueTimeSheetDTO>> GetAllOfIssueAsync(ObjectId issueId)
         {
-            var timeSheets = (await _issueRepo.GetAsync(issueId)).TimeSheets;
+            Issue issue = await _issueRepo.GetAsync(issueId);
+
+            await CanUserReadTimeSheetsAsync(issue);
+
+            var timeSheets = issue.TimeSheets;
             return (await Task.WhenAll(timeSheets.Select(MapToTimeSheetDTO))).ToList();
         }
 
         public async Task<IssueTimeSheetDTO> GetAsync(ObjectId issueId, ObjectId timeSheetId)
         {
-            var timeSheet = (await _issueRepo.GetAsync(issueId)).TimeSheets.First(it => it.Id.Equals(timeSheetId));
+            Issue issue = await _issueRepo.GetAsync(issueId);
+
+            await CanUserReadTimeSheetsAsync(issue);
+
+            var timeSheet = issue.TimeSheets.First(it => it.Id.Equals(timeSheetId));
             return await MapToTimeSheetDTO(timeSheet);
         }
 

--- a/Goose.Tests/Application.IntegrationTests/Message/MessageTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/Message/MessageTests.cs
@@ -43,7 +43,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             responce = await helper.client.GetAsync(uri);
             Assert.IsTrue(responce.IsSuccessStatusCode);
             var messageList = await responce.Parse<IList<MessageDTO>>();
-            Assert.IsTrue(messageList.Count == 1);
+            Assert.AreEqual(1, messageList.Count);
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             responce = await helper.client.GetAsync(uri);
             Assert.IsTrue(responce.IsSuccessStatusCode);
             var messageList = await responce.Parse<IList<MessageDTO>>();
-            Assert.IsTrue(messageList.Count == 1);
+            Assert.AreEqual(1, messageList.Count);
 
             uri = $"/api/messages/{messageList[0].Id}";
             responce = await helper.client.DeleteAsync(uri);
@@ -90,7 +90,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             responce = await helper.client.GetAsync(uri);
             Assert.IsTrue(responce.IsSuccessStatusCode);
             messageList = await responce.Parse<IList<MessageDTO>>();
-            Assert.IsTrue(messageList.Count == 0);
+            Assert.AreEqual(0, messageList.Count);
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             Assert.IsTrue(responce.IsSuccessStatusCode);
             var messageList = await responce.Parse<IList<MessageDTO>>();
 
-            Assert.IsTrue(messageList.Count == 1);
+            Assert.AreEqual(1, messageList.Count);
         }
 
         [Test]
@@ -156,7 +156,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             Assert.IsTrue(responce.IsSuccessStatusCode);
             var messageList = await responce.Parse<IList<MessageDTO>>();
 
-            Assert.IsTrue(messageList.Count == 0);
+            Assert.AreEqual(0, messageList.Count);
 
             //Create Second Sheet which accours the Time Exceeding
             var timeSheetDTO2 = new IssueTimeSheetDTO()
@@ -184,7 +184,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             Assert.IsTrue(responce.IsSuccessStatusCode);
             var messageList2 = await responce.Parse<IList<MessageDTO>>();
 
-            Assert.IsTrue(messageList2.Count == 1);
+            Assert.AreEqual(1, messageList2.Count);
         }
 
         [Test]
@@ -207,18 +207,18 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             Assert.IsTrue(responce.IsSuccessStatusCode);
             var messageList = await responce.Parse<IList<MessageDTO>>();
 
-            Assert.IsTrue(messageList.Count == 1);
+            Assert.AreEqual(1, messageList.Count);
         }
 
         [Test]
         public async Task TimeSheetMessageTest4()
         {
             using var helper = await new SimpleTestHelperBuilderMessage().Build();
-            var newUserId = await helper.Helper.GenerateUserAndSetToProject(helper.Company.Id, helper.Project.Id, Role.EmployeeRole);
+            var newUser = await helper.Helper.GenerateUserAndSetToProject(helper.Company.Id, helper.Project.Id, Role.EmployeeRole);
 
             IssueTimeSheetDTO timeSheetDTO = new IssueTimeSheetDTO()
             {
-                User = new UserDTO(await helper.Helper.UserRepository.GetAsync(newUserId)),
+                User = new UserDTO(await helper.Helper.UserRepository.GetAsync(newUser.Id)),
                 Start = DateTime.Now
             };
 
@@ -238,12 +238,12 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             responce = await helper.client.PutAsync(uri, createdSheet.ToStringContent());
             Assert.IsTrue(responce.IsSuccessStatusCode);
 
-            uri = $"/api/messages/{newUserId}";
+            uri = $"/api/messages/{newUser.Id}";
             responce = await helper.client.GetAsync(uri);
             Assert.IsTrue(responce.IsSuccessStatusCode);
             var messageList = await responce.Parse<IList<MessageDTO>>();
 
-            Assert.IsTrue(messageList.Count == 1);
+            Assert.AreEqual(1, messageList.Count);
         }
 
         [Test]
@@ -267,7 +267,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             Assert.IsTrue(response.IsSuccessStatusCode);
             var messageList = await response.Parse<IList<MessageDTO>>();
 
-            Assert.IsTrue(messageList.Count == 2);
+            Assert.AreEqual(2, messageList.Count);
         }
 
         [Test]
@@ -291,7 +291,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             Assert.IsTrue(response.IsSuccessStatusCode);
             var messageList = await response.Parse<IList<MessageDTO>>();
 
-            Assert.IsTrue(messageList.Count == 0);
+            Assert.AreEqual(0, messageList.Count);
         }
 
         [Test]
@@ -321,7 +321,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             Assert.IsTrue(response.IsSuccessStatusCode);
             var messageList = await response.Parse<IList<MessageDTO>>();
 
-            Assert.IsTrue(messageList.Count == 1);
+            Assert.AreEqual(1, messageList.Count);
         }
 
         private Domain.Models.Message GetValidMessage(SimpleTestHelper helper)

--- a/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
@@ -107,7 +107,7 @@ namespace Goose.Tests.Application.IntegrationTests
         }
 
 
-        public async Task<ObjectId> GenerateUserAndSetToProject(ObjectId companyId, ObjectId projectId,
+        public async Task<UserDTO> GenerateUserAndSetToProject(ObjectId companyId, ObjectId projectId,
             params Role[] roles)
         {
             var login = new PropertyUserLoginDTO
@@ -120,7 +120,7 @@ namespace Goose.Tests.Application.IntegrationTests
             return await GenerateUserAndSetToProject(companyId, projectId, login, roles);
         }
 
-        public async Task<ObjectId> GenerateUserAndSetToProject(ObjectId companyId, ObjectId projectId, PropertyUserLoginDTO user,
+        public async Task<UserDTO> GenerateUserAndSetToProject(ObjectId companyId, ObjectId projectId, PropertyUserLoginDTO user,
             params Role[] roles)
         {
             //generate User 
@@ -137,7 +137,7 @@ namespace Goose.Tests.Application.IntegrationTests
             });
 
             _client.Auth(signInResult);
-            return signInResult.User.Id;
+            return signInResult.User;
         }
 
         public async Task<HttpResponseMessage> GenerateIssue(UserDTO user, ProjectDTO project, Action<IssueDTO> withIssue = null)

--- a/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
@@ -26,10 +26,9 @@ namespace Goose.Tests.Application.IntegrationTests
     {
         private readonly HttpClient _client;
 
-        private SignInResponse LoggedInUser { get; set; }
-        private List<ObjectId> _companies = new();
-        private List<ObjectId> _projects = new();
-        private List<ObjectId> _issues = new();
+        private readonly List<ObjectId> _companies = new();
+        private readonly List<ObjectId> _projects = new();
+        private readonly List<ObjectId> _issues = new();
 
 
         public ICompanyRepository CompanyRepository { get; }

--- a/Goose.Tests/Application.IntegrationTests/SimpleTestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/SimpleTestHelper.cs
@@ -59,7 +59,7 @@ namespace Goose.Tests.Application.IntegrationTests
             return await Helper.GenerateIssue(Project, copy);
         }
 
-        public async Task<ObjectId> GenerateUserAndSetToProject(params Role[] roles)
+        public async Task<UserDTO> GenerateUserAndSetToProject(params Role[] roles)
         {
             client.Auth(SignIn);
             return await Helper.GenerateUserAndSetToProject(Company.Id, Project.Id, roles);

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueRightTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueRightTests.cs
@@ -245,7 +245,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
         public async Task WriteMessageAsEmployee()
         {
             using var helper = await new SimpleTestHelperBuilderIssueRights().Build();
-            var userId = await helper.Helper.GenerateUserAndSetToProject(helper.Company.Id, helper.Project.Id, Role.EmployeeRole);
+            var user = await helper.Helper.GenerateUserAndSetToProject(helper.Company.Id, helper.Project.Id, Role.EmployeeRole);
 
             var newItem = new IssueConversationDTO()
             {
@@ -260,7 +260,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
 
             var issue = await helper.GetIssueAsync(helper.Issue.Id);
             var latestConversationItem = issue.ConversationItems.Last();
-            Assert.AreEqual(latestConversationItem.CreatorUserId, userId);
+            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.MessageType);
             Assert.AreEqual(latestConversationItem.Data, "TestConversation");
         }
@@ -270,7 +270,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
         public async Task WriteMessageAsCustomer()
         {
             using var helper = await new SimpleTestHelperBuilderIssueRights().Build();
-            var userId = await helper.Helper.GenerateUserAndSetToProject(helper.Company.Id, helper.Project.Id, Role.CustomerRole);
+            var user = await helper.Helper.GenerateUserAndSetToProject(helper.Company.Id, helper.Project.Id, Role.CustomerRole);
 
             var newItem = new IssueConversationDTO()
             {
@@ -285,7 +285,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
 
             var issue = await helper.GetIssueAsync(helper.Issue.Id);
             var latestConversationItem = issue.ConversationItems.Last();
-            Assert.AreEqual(latestConversationItem.CreatorUserId, userId);
+            Assert.AreEqual(latestConversationItem.CreatorUserId, user.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.MessageType);
             Assert.AreEqual(latestConversationItem.Data, "TestConversation");
         }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueTimesheetTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueTimesheetTests.cs
@@ -1,0 +1,51 @@
+﻿using Goose.Domain.Models.Identity;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Goose.Tests.Application.IntegrationTests.issues
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    class IssueTimeSheetTests
+    {
+        [Test]
+        public async Task ReadTimeSheetsRightsTest()
+        {
+            var expected = new Dictionary<Role, HttpStatusCode>()
+            {
+                { Role.CustomerRole, HttpStatusCode.Forbidden },
+                { Role.ReadonlyEmployeeRole, HttpStatusCode.OK },
+                { Role.EmployeeRole, HttpStatusCode.OK },
+                { Role.ProjectLeaderRole, HttpStatusCode.OK },
+                { Role.CompanyRole, HttpStatusCode.OK },
+            };
+
+            foreach (var (role, expectedStatus) in expected)
+            {
+                var result = await GetTimeSheetsWithRole(role);
+                var actualStatus = result.StatusCode;
+                Assert.AreEqual(
+                    expectedStatus,
+                    actualStatus,
+                    $"Expected: {expectedStatus}\nBut was: {actualStatus}\nFor Role {role.Name}");
+            }
+        }
+
+        public static async Task<HttpResponseMessage> GetTimeSheetsWithRole(Role role)
+        {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            await helper.GenerateUserAndSetToProject(role);
+
+            var issueId = helper.Issue.Id;
+            var uri = $"/api/issues/{issueId}/timesheets/";
+
+            return await helper.client.GetAsync(uri);
+        }
+    }
+}

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueTimesheetTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueTimesheetTests.cs
@@ -1,4 +1,5 @@
-﻿using Goose.Domain.Models.Identity;
+﻿using Goose.Domain.DTOs.Issues;
+using Goose.Domain.Models.Identity;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -46,6 +47,106 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var uri = $"/api/issues/{issueId}/timesheets/";
 
             return await helper.client.GetAsync(uri);
+        }
+
+        /// <summary>
+        /// Dieser Test überprüft, das beim starten einer neuen Zeiterfassung die Alte gestoppt wird.
+        /// Der Ablauf:
+        /// 1. Der Nutzer erstellt eine Zeiterfassung, und stoppt sie.
+        /// 2. Danash startet er eine zweite Zeiterfassung ohne sie zu stoppen.
+        /// 3. Dann startet er eine dritte ZE für ein anderes Ticket, wodurch die zweite ZE gestoppt wird.
+        /// Die erste ZE soll unverändert bleiben.
+        /// Außerdem wird noch für einen anderen Nutzer eine ZE gestartet, um zu überprüfen,
+        /// das Diese bei Schritt 3 nicht beendet wird.
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public static async Task TimeSheetCancellation()
+        {
+            var now = new DateTime(2020, 5, 19, 12, 0, 0, DateTimeKind.Utc);
+
+            // Create all the timesheets
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var secondaryUser = helper.User;
+
+            var issueId = helper.Issue.Id;
+            var timeSheetsUri = $"/api/issues/{issueId}/timesheets/";
+
+            var firstTimeSheet = new IssueTimeSheetDTO()
+            {
+                User = secondaryUser,
+                Start = now,
+            };
+
+            var result = await helper.client.PostAsync(timeSheetsUri, firstTimeSheet.ToStringContent());
+            Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
+
+            var primaryUser = await helper.GenerateUserAndSetToProject(Role.EmployeeRole);
+            Assert.AreNotEqual(secondaryUser.Id, primaryUser.Id);
+
+            var secondTimeSheet = new IssueTimeSheetDTO()
+            {
+                User = primaryUser,
+                Start = now.AddDays(-1),
+                End = now.AddHours(-2),
+            };
+
+            result = await helper.client.PostAsync(timeSheetsUri, secondTimeSheet.ToStringContent());
+            Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
+
+            var thirdTimeSheet = new IssueTimeSheetDTO()
+            {
+                User = primaryUser,
+                Start = now.AddHours(-1),
+                // Open ended
+            };
+
+            result = await helper.client.PostAsync(timeSheetsUri,thirdTimeSheet.ToStringContent());
+            Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
+
+            var content = await helper.CreateIssue();
+            var otherIssue = await content.Parse<IssueDTO>();
+            var timeSheetsOfOtherIssueUri = $"/api/issues/{otherIssue.Id}/timesheets/";
+
+            var fourthTimeSheet = new IssueTimeSheetDTO()
+            {
+                User = primaryUser,
+                Start = now,
+                // Open ended
+            };
+
+            result = await helper.client.PostAsync(timeSheetsOfOtherIssueUri, fourthTimeSheet.ToStringContent());
+            Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
+
+
+            // check the state of all timesheets
+            result = await helper.client.GetAsync(timeSheetsUri);
+            Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+
+            var timeSheets = await result.Parse<IList<IssueTimeSheetDTO>>();
+            Assert.AreEqual(3, timeSheets.Count);
+
+            AssertTimeSheetsAreEqualExceptId(firstTimeSheet, timeSheets[0]);
+            AssertTimeSheetsAreEqualExceptId(secondTimeSheet, timeSheets[1]);
+            Assert.AreEqual(thirdTimeSheet.User.Id, timeSheets[2].User.Id);
+            Assert.AreEqual(thirdTimeSheet.Start, timeSheets[2].Start);
+            Assert.AreNotEqual(default(DateTime), timeSheets[2].End); // end time must have been set
+
+            // check other timesheet
+            result = await helper.client.GetAsync(timeSheetsOfOtherIssueUri);
+            Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+
+            var otherTimeSheets = await result.Parse<IList<IssueTimeSheetDTO>>();
+            Assert.AreEqual(1, otherTimeSheets.Count);
+
+            AssertTimeSheetsAreEqualExceptId(fourthTimeSheet, otherTimeSheets[0]);
+        }
+
+        public static void AssertTimeSheetsAreEqualExceptId(IssueTimeSheetDTO expected, IssueTimeSheetDTO actual)
+        {
+            Assert.AreEqual(expected.User.Id, actual.User.Id);
+            Assert.AreEqual(expected.Start, actual.Start);
+            Assert.AreEqual(expected.End, actual.End);
         }
     }
 }


### PR DESCRIPTION
Enthält im Prinzip zwei Sachen:

T20: Nur Mitarbeiter und Firma können Zeiterfassungen sehen
T21 + T22: Beim Starten einer Zeiterfassung werden eventuell alte, noch laufende Zeiterfassungen des Nutzers gestoppt. Falls bei einem dieser Issues die geschätzte Zeit überschritten wird, wird eine Nachricht generiert.

Tests wurden gleich mit erstellt.