### PR TITLE
Feature/child issue dependent properties

### DIFF
--- a/Goose.API/Repositories/IssueRepository.cs
+++ b/Goose.API/Repositories/IssueRepository.cs
@@ -20,6 +20,8 @@ namespace Goose.API.Repositories
         public Task CreateOrUpdateConversationItemAsync(string issueId, IssueConversation issueConversation);
         public Task<IssueRequirement> GetRequirementByIdAsync(ObjectId issueId, ObjectId requirementId);
         public Task<IList<Issue>> GetIssuesWithOpenTimeSheetsAsync(ObjectId userId);
+
+        public Task<IList<Issue>> GetChildrenOfIssueAsync(ObjectId issueId);
     }
 
     public class IssueRepository : Repository<Issue>, IIssueRepository
@@ -119,6 +121,12 @@ namespace Goose.API.Repositories
             );
 
             var result = await _dbCollection.FindAsync(query);
+            return await result.ToListAsync();
+        }
+
+        public async Task<IList<Issue>> GetChildrenOfIssueAsync(ObjectId issueId)
+        {
+            var result = await _dbCollection.FindAsync(x => x.ParentIssueId == issueId);
             return await result.ToListAsync();
         }
     }

--- a/Goose.API/Repositories/IssueRepository.cs
+++ b/Goose.API/Repositories/IssueRepository.cs
@@ -20,8 +20,6 @@ namespace Goose.API.Repositories
         public Task CreateOrUpdateConversationItemAsync(string issueId, IssueConversation issueConversation);
         public Task<IssueRequirement> GetRequirementByIdAsync(ObjectId issueId, ObjectId requirementId);
         public Task<IList<Issue>> GetIssuesWithOpenTimeSheetsAsync(ObjectId userId);
-
-        public Task<IList<Issue>> GetChildrenOfIssueAsync(ObjectId issueId);
     }
 
     public class IssueRepository : Repository<Issue>, IIssueRepository
@@ -121,12 +119,6 @@ namespace Goose.API.Repositories
             );
 
             var result = await _dbCollection.FindAsync(query);
-            return await result.ToListAsync();
-        }
-
-        public async Task<IList<Issue>> GetChildrenOfIssueAsync(ObjectId issueId)
-        {
-            var result = await _dbCollection.FindAsync(x => x.ParentIssueId == issueId);
             return await result.ToListAsync();
         }
     }

--- a/Goose.API/Services/issues/IssueParentService.cs
+++ b/Goose.API/Services/issues/IssueParentService.cs
@@ -42,7 +42,7 @@ namespace Goose.API.Services.issues
             _associationHelper = associationHelper;
         }
 
-        public async Task<IssueDTO>? GetParent(ObjectId issueId)
+        public async Task<IssueDTO?> GetParent(ObjectId issueId)
         {
             var parentId = (await _issueRepository.GetAsync(issueId)).ParentIssueId;
             if (parentId == null) return null;

--- a/Goose.API/Services/issues/IssueParentService.cs
+++ b/Goose.API/Services/issues/IssueParentService.cs
@@ -69,13 +69,11 @@ namespace Goose.API.Services.issues
 
             await _associationHelper.CanAddChild(parent, issue);
 
-            issue.IssueDetail.Priority = parent.IssueDetail.Priority;
             issue.ParentIssueId = parentId;
             parent.ChildrenIssueIds.Add(issueId);
             await Task.WhenAll(_issueRepository.UpdateAsync(issue), _issueRepository.UpdateAsync(parent));
 
-            // the issue might have grandchildren which need updating too.
-            await _issueService.PropagateDependentProperties(issue);
+            await _issueService.PropagateDependentProperties(parent);
 
             // ConversationItem im Oberticket hinzufügen
             parent.ConversationItems.Add(new IssueConversation()

--- a/Goose.Domain/Models/tickets/Issue.cs
+++ b/Goose.Domain/Models/tickets/Issue.cs
@@ -22,6 +22,7 @@ namespace Goose.Domain.Models.Issues
         public ObjectId? ParentIssueId { get; set; }
         public IList<ObjectId> ChildrenIssueIds { get; set; }
         public IList<ObjectId> PredecessorIssueIds { get; set; }
+        public IList<ObjectId> InheritedPredecessorIssueIds { get; set; }
         public IList<ObjectId> SuccessorIssueIds { get; set; }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
@@ -309,6 +309,12 @@ namespace Goose.Tests.Application.IntegrationTests
             _client.Auth(signIn);
         }
 
+        public async Task<HttpResponseMessage> PutIssue(IssueDTO issue)
+        {
+            var uri = $"api/projects/{issue.Project.Id}/issues/{issue.Id}/";
+            return await _client.PutAsync(uri, issue.ToStringContent());
+        }
+
         #endregion
 
         #region Utils

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueParentTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueParentTests.cs
@@ -87,36 +87,41 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         public async Task DependentPropertiesGetSetWhenParentIsAdded()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
-            var parentIssue = helper.Issue;
+            var parentIssueDto = helper.Issue;
 
-            var childIssueDto = parentIssue.Copy();
+            var predecessorDto = await helper.CreateIssue().Parse<IssueDTO>();
+            var uri = $"api/issues/{parentIssueDto.Id}/predecessors/{predecessorDto.Id}";
+            var result = await helper.client.PutAsync(uri, null);
+            Assert.IsTrue(result.IsSuccessStatusCode);
+
+            var childIssueDto = parentIssueDto.Copy();
             childIssueDto.Id = ObjectId.Empty;
 
-            // TODO check predecessors
-            childIssueDto.IssueDetail.Priority = parentIssue.IssueDetail.Priority + 1;
+            childIssueDto.IssueDetail.Priority = parentIssueDto.IssueDetail.Priority + 1;
 
             childIssueDto = await helper.CreateIssue(childIssueDto).Parse<IssueDTO>();
-            await helper.Helper.SetParentIssue(parentIssue.Id, childIssueDto.Id);
+            await helper.Helper.SetParentIssue(parentIssueDto.Id, childIssueDto.Id);
 
             var childIssue = await helper.Helper.GetIssueAsync(childIssueDto.Id);
 
-            Assert.AreEqual(parentIssue.IssueDetail.Priority, childIssue.IssueDetail.Priority);
+            Assert.AreEqual(parentIssueDto.IssueDetail.Priority, childIssue.IssueDetail.Priority);
+            Assert.AreEqual(1, childIssue.InheritedPredecessorIssueIds.Count);
+            Assert.AreEqual(predecessorDto.Id, childIssue.InheritedPredecessorIssueIds[0]);
         }
 
         [Test]
         public async Task VisibilityStatusOfParentAndChildMustBeIndentical()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
-            var parentIssue = helper.Issue;
+            var parentIssueDto = helper.Issue;
 
-            var childIssue = parentIssue.Copy();
-            childIssue.Id = ObjectId.Empty;
+            var childIssueDto = parentIssueDto.Copy();
+            childIssueDto.Id = ObjectId.Empty;
 
-            // TODO check predecessors
-            childIssue.IssueDetail.Visibility = !parentIssue.IssueDetail.Visibility;
+            childIssueDto.IssueDetail.Visibility = !parentIssueDto.IssueDetail.Visibility;
 
-            childIssue = await helper.CreateIssue(childIssue).Parse<IssueDTO>();
-            var result = await helper.Helper.SetParentIssue(parentIssue.Id, childIssue.Id);
+            childIssueDto = await helper.CreateIssue(childIssueDto).Parse<IssueDTO>();
+            var result = await helper.Helper.SetParentIssue(parentIssueDto.Id, childIssueDto.Id);
 
             Assert.AreEqual(HttpStatusCode.BadRequest, result.StatusCode);
         }
@@ -127,6 +132,11 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             using var helper = await new SimpleTestHelperBuilder().Build();
             var parentIssueDto = helper.Issue;
 
+            var predecessorDto = await helper.CreateIssue().Parse<IssueDTO>();
+            var uri = $"api/issues/{parentIssueDto.Id}/predecessors/{predecessorDto.Id}";
+            var result = await helper.client.PutAsync(uri, null);
+            Assert.IsTrue(result.IsSuccessStatusCode);
+
             var childIssueDto = await helper.CreateIssue().Parse<IssueDTO>();
             await helper.Helper.SetParentIssue(parentIssueDto.Id, childIssueDto.Id);
 
@@ -135,14 +145,19 @@ namespace Goose.Tests.Application.IntegrationTests.issues
 
             parentIssueDto.IssueDetail.Priority += 1;
 
-            var result = await helper.Helper.PutIssue(parentIssueDto);
+            result = await helper.Helper.PutIssue(parentIssueDto);
             Assert.IsTrue(result.IsSuccessStatusCode);
 
             var childIssue = await helper.GetIssueAsync(childIssueDto.Id);
             var grandChildIssue = await helper.GetIssueAsync(grandChildIssueDto.Id);
 
             Assert.AreEqual(parentIssueDto.IssueDetail.Priority, childIssue.IssueDetail.Priority);
+            Assert.AreEqual(1, childIssue.InheritedPredecessorIssueIds.Count);
+            Assert.AreEqual(predecessorDto.Id, childIssue.InheritedPredecessorIssueIds[0]);
+
             Assert.AreEqual(parentIssueDto.IssueDetail.Priority, grandChildIssue.IssueDetail.Priority);
+            Assert.AreEqual(1, grandChildIssue.InheritedPredecessorIssueIds.Count);
+            Assert.AreEqual(predecessorDto.Id, grandChildIssue.InheritedPredecessorIssueIds[0]);
         }
 
         [Test]


### PR DESCRIPTION
Resolves #100 

Das Vererben von den Predecessors hat mir ein wenig Kopfschmerzen bereitet. Ich habe das jetzt so gelöst, das die Vererbten Vorgänger in einem zusätzlichen Array gespeichert werden. Damit kann man Änderungen relativ einfach an Untertickets weiterleiten.