### PR TITLE
Feature/Untertickets und Vorgänger

### DIFF
--- a/Goose.API/Controllers/issuesControllers/IssueSuccessorsController.cs
+++ b/Goose.API/Controllers/issuesControllers/IssueSuccessorsController.cs
@@ -18,7 +18,7 @@ namespace Goose.API.Controllers.IssuesControllers
         {
             _issueService = issueService;
         }
-        
+
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -26,5 +26,9 @@ namespace Goose.API.Controllers.IssuesControllers
         {
             return await _issueService.GetAll(issueId);
         }
+
+/*
+             * Issue wird blockiert wenn:
+             * 1) Das Oberticket nicht in der Bearbeitungsphase ist*/
     }
 }

--- a/Goose.API/Services/issues/IssueAssociationHelper.cs
+++ b/Goose.API/Services/issues/IssueAssociationHelper.cs
@@ -12,6 +12,7 @@ namespace Goose.API.Services.issues
     {
         public Task CanAddChild(Issue parent, Issue other);
         public Task CanAddPredecessor(Issue successor, Issue other);
+        public Task<IList<Issue>> GetChildrenRecursive(Issue issue);
     }
 
     public class IssueAssociationHelper : IIssueAssociationHelper
@@ -67,6 +68,12 @@ namespace Goose.API.Services.issues
                     $"{parent.Id} and {other.Id} belong to the same hierarchy. Cannot associate issue or an endless loop would occur");
 
             await CanAddAssociation(projectIssues, parent, other);
+        }
+
+        public async Task<IList<Issue>> GetChildrenRecursive(Issue issue)
+        {
+            var projectIssues = await _issueRepository.GetAllOfProjectAsync(issue.ProjectId);
+            return GetChildrenRecursive(projectIssues, issue);
         }
 
         public async Task CanAddPredecessor(Issue successor, Issue other)

--- a/Goose.API/Services/issues/IssuePredecessorService.cs
+++ b/Goose.API/Services/issues/IssuePredecessorService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Goose.API.Repositories;
 using Goose.API.Services.issues;
 using Goose.API.Utils.Authentication;
+using Goose.API.Utils.Exceptions;
 using Goose.Domain.DTOs.Issues;
 using Goose.Domain.Models.Issues;
 using Microsoft.AspNetCore.Http;
@@ -47,6 +48,8 @@ namespace Goose.API.Services.Issues
         {
             var successor = await _issueRepo.GetAsync(successorId);
             var predecessor = await _issueRepo.GetAsync(predecessorId);
+            if (!predecessor.IssueDetail.Visibility && successor.IssueDetail.Visibility)
+                throw new HttpStatusException(400, "An intern issue cannot be the predecessor of an extern issue");
 
             await _associationHelper.CanAddPredecessor(successor, predecessor);
             

--- a/Goose.API/Services/issues/IssuePredecessorService.cs
+++ b/Goose.API/Services/issues/IssuePredecessorService.cs
@@ -22,9 +22,6 @@ namespace Goose.API.Services.Issues
 
     public class IssuePredecessorService : IIssuePredecessorService
     {
-        //TODO ggf müssen vorgänger rekursiv entfernt werden?
-
-        //TODO wie bekommt man am besten alle issues in einem vorgänger baum? phil fragen?
         private readonly IIssueRepository _issueRepo;
         private readonly IIssueService _issueService;
         private readonly IIssueAssociationHelper _associationHelper;

--- a/Goose.API/Services/issues/IssueRequirementService.cs
+++ b/Goose.API/Services/issues/IssueRequirementService.cs
@@ -37,7 +37,7 @@ namespace Goose.API.Services.Issues
         public async Task<IssueRequirement> GetAsync(ObjectId issueId, ObjectId requirementId)
         {
             return (await _issueRepo.GetAsync(issueId)).IssueDetail.Requirements.First(
-                it => it.Id.Equals(requirementId)) ?? throw new HttpStatusException(400, "Das angefragte Ticket existiert nicht");
+                it => it.Id.Equals(requirementId));
         }
 
         public async Task<IssueRequirement> CreateAsync(ObjectId issueId, IssueRequirement requirement)

--- a/Goose.API/Services/issues/IssueStateService.cs
+++ b/Goose.API/Services/issues/IssueStateService.cs
@@ -190,7 +190,18 @@ namespace Goose.API.Services.issues
          */
         public async Task<StateDTO> GetNewStateUpdateAssociatedIssues(Issue issue, StateDTO newState)
         {
+            if (issue.StateId == newState.Id) return newState;
             return await _updateStateHandler.HandleStateUpdate(issue, await _stateService.GetState(issue.ProjectId, issue.StateId), newState);
+        }
+
+        private async Task<StateDTO> GetStateByName(Issue issue, string name)
+        {
+            return (await _stateService.GetStates(issue.ProjectId)).First(it => it.Name == name);
+        }
+
+        private async Task<StateDTO> GetState(Issue issue)
+        {
+            return await _stateService.GetState(issue.ProjectId, issue.StateId);
         }
 
         private async Task TryCatch(Task task)
@@ -202,18 +213,6 @@ namespace Goose.API.Services.issues
             catch (Exception)
             {
             }
-        }
-
-        private async Task<StateDTO> GetStateByName(Issue issue, string name)
-        {
-            return (await _stateService.GetStates(issue.ProjectId)).First(it => it.Name == name);
-        }
-
-        private StateDTO GetStateFromList(ObjectId id, IList<StateDTO> states) => states.First(it => it.Id == id);
-
-        private async Task<StateDTO> GetState(Issue issue)
-        {
-            return await _stateService.GetState(issue.ProjectId, issue.StateId);
         }
     }
 

--- a/Goose.API/Services/issues/IssueStateService.cs
+++ b/Goose.API/Services/issues/IssueStateService.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Goose.API.Repositories;
+using Goose.API.Utils;
+using Goose.API.Utils.Exceptions;
+using Goose.Domain.DTOs;
+using Goose.Domain.Models.Issues;
+using Goose.Domain.Models.Projects;
+using MongoDB.Bson;
+
+namespace Goose.API.Services.issues
+{
+    public interface IIssueStateService
+    {
+        public Task<StateDTO> UpdateState(Issue issue, StateDTO newState);
+        public Task<StateDTO> GetNewStateUpdateAssociatedIssues(Issue issue, StateDTO newState);
+    }
+
+    public class IssueStateService : IIssueStateService
+    {
+        private readonly IIssueRepository _issueRepository;
+        private readonly IStateService _stateService;
+        private readonly IIssueAssociationHelper _associationHelper;
+
+        private readonly IFsmHandler<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>, StateDTO> _updateStateHandler = new FsmHandler();
+
+        public IssueStateService(IIssueRepository issueRepository, IStateService stateService, IIssueAssociationHelper associationHelper)
+        {
+            _issueRepository = issueRepository;
+            _stateService = stateService;
+            _associationHelper = associationHelper;
+
+            RegisterFsmEvents();
+        }
+
+        public void RegisterFsmEvents()
+        {
+            _updateStateHandler.AddEvent(new FsmEvent<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>> //CheckingState -> NegotiationState
+            {
+                OldState = State.CheckingState,
+                NewState = State.NegotiationState,
+                Func = async (issue, oldState, newState) => newState
+            });
+            _updateStateHandler.AddEvent(new FsmEvent<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>> //NegotiationState -> ProcessingState
+            {
+                OldState = State.NegotiationState,
+                NewState = State.ProcessingState,
+                Func = async (issue, oldState, newState) =>
+                {
+                    //TODO nur wenn zusammenfassung akzeptiert ist
+
+                    /*
+                     * Das Issue wird in Waiting gesetzt wenn das Startdatum noch nicht erreicht ist
+                     */
+                    if (issue.IssueDetail.StartDate < DateTime.Now)
+                    {
+                        return await GetStateByName(issue, State.WaitingState);
+                    }
+
+                    Task<Issue> parent = null;
+                    if (issue.ParentIssueId is { } parentId) parent = _issueRepository.GetAsync(parentId);
+                    var predecessors = Task.WhenAll(issue.PredecessorIssueIds.Select(_issueRepository.GetAsync));
+
+
+                    Task<StateDTO> parentState = null;
+                    if (parent is { } parentNotNull) parentState = _stateService.GetState((await parentNotNull).ProjectId, (await parentNotNull).Id);
+                    var predecessorStates = Task.WhenAll((await predecessors).Select(it => _stateService.GetState(it.ProjectId, it.StateId)));
+
+                    /*
+                     * Issue wird blockiert wenn:
+                     * 1) Das Oberticket nicht in der Bearbeitungsphase ist
+                     * 2) Nicht alle Vorgänger abgeschlossen sind
+                     * 
+                     */
+                    if (parentState != null && (await parentState).Phase == State.NegotiationPhase ||
+                        (await predecessorStates).HasWhere(it => it.Phase != State.ConclusionPhase))
+                    {
+                        return await GetStateByName(issue, State.BlockedState);
+                    }
+
+                    return newState;
+                }
+            });
+            _updateStateHandler.AddEvent(new FsmEvent<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>> //Cancel Issue
+            {
+                OldState = "",
+                NewState = State.CancelledState,
+                Func = async (issue, oldState, newState) =>
+                {
+                    //Cancels all children
+                    var children = await _associationHelper.GetChildrenRecursive(issue);
+                    await Task.WhenAll(children.Select(it => UpdateState(it, newState)));
+                    //TODO was ist mit nachfolgern
+                    return newState;
+                }
+            });
+            _updateStateHandler.AddEvent(new FsmEvent<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>> //CheckingState -> NegotiationState
+            {
+                OldState = State.CheckingState,
+                NewState = State.NegotiationState,
+                Func = async (issue, oldState, newState) => newState
+            });
+            _updateStateHandler.AddEvent(new FsmEvent<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>> //ProcessingState -> ReviewState
+            {
+                OldState = State.ProcessingState,
+                NewState = State.ReviewState,
+                Func = async (issue, oldState, newState) =>
+                {
+                    var children = await Task.WhenAll(issue.ChildrenIssueIds.Select(_issueRepository.GetAsync));
+                    var childrenStates = await Task.WhenAll(children.Select(it => _stateService.GetState(it.ProjectId, it.StateId)));
+                    if (childrenStates.HasWhere(it => it.Phase != State.ConclusionPhase))
+                        throw new HttpStatusException(400, "At least one sub issue is not in conclusion phase");
+                    return newState;
+                }
+            });
+            _updateStateHandler.AddEvent(new FsmEvent<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>> //ReviewState -> CompletedState
+            {
+                OldState = State.ReviewState,
+                NewState = State.CompletedState,
+                Func = async (issue, oldState, newState) =>
+                {
+                    //TODO Projektleiter überprüft ticket
+                    await OnIssueReachedCompletionPhase(issue);
+                    return newState;
+                }
+            });
+            _updateStateHandler.AddEvent(new FsmEvent<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>> //CompletedState -> ArchivedState
+            {
+                OldState = State.CompletedState,
+                NewState = State.ArchivedState,
+                Func = async (issue, oldState, newState) =>
+                {
+                    //TODO Abschlusskommentar
+                    await OnIssueReachedCompletionPhase(issue);
+                    return newState;
+                }
+            });
+        }
+
+        private async Task OnIssueReachedCompletionPhase(Issue issue, Issue? _parent = null, IList<Issue>? _successors = null)
+        {
+            Task<Issue> parentAsync = null;
+            if (_parent != null) parentAsync = Task.FromResult(_parent);
+            else if (issue.ParentIssueId is { } parentId) parentAsync = _issueRepository.GetAsync(parentId);
+
+            var successors = _successors == null
+                ? Task.WhenAll(issue.SuccessorIssueIds.Select(_issueRepository.GetAsync))
+                : Task.FromResult(_successors.ToArray());
+
+            try
+            {
+                var processingState = await GetStateByName(issue, State.ProcessingState);
+                var blockedState = await GetStateByName(issue, State.BlockedState);
+                var tasks = new List<Task>();
+                var parent = parentAsync != null ? await parentAsync : null;
+                if (parent is { } parentNotNull)
+                {
+                    if (parentNotNull.StateId == blockedState.Id)
+                        tasks.Add(TryCatch(UpdateState(parentNotNull, processingState)));
+                }
+
+                var blockedSuccessors = (await successors).Where(it => it.StateId == blockedState.Id);
+                tasks.AddRange(blockedSuccessors.Select(it => TryCatch(UpdateState(it, processingState))));
+
+                await Task.WhenAll(tasks);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+
+        /*
+         * Gibt den neuen Status zurück (schmeißt eine Exception wenn der Status nicht geändert werden kann).
+         * Updated Issue und alle abhängigen Issues
+         */
+        public async Task<StateDTO> UpdateState(Issue issue, StateDTO newState)
+        {
+            var state = await GetNewStateUpdateAssociatedIssues(issue, newState);
+            issue.StateId = state.Id;
+            await _issueRepository.UpdateAsync(issue);
+            return state;
+        }
+
+        /*
+         * Gibt den neuen Status zurück (schmeißt eine Exception wenn der Status nicht geändert werden kann).
+         * Der Status von jeden abhängigem Issue wird ebenfalls geupdated 
+         */
+        public async Task<StateDTO> GetNewStateUpdateAssociatedIssues(Issue issue, StateDTO newState)
+        {
+            return await _updateStateHandler.HandleStateUpdate(issue, await _stateService.GetState(issue.ProjectId, issue.StateId), newState);
+        }
+
+        private async Task TryCatch(Task task)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private async Task<StateDTO> GetStateByName(Issue issue, string name)
+        {
+            return (await _stateService.GetStates(issue.ProjectId)).First(it => it.Name == name);
+        }
+
+        private StateDTO GetStateFromList(ObjectId id, IList<StateDTO> states) => states.First(it => it.Id == id);
+
+        private async Task<StateDTO> GetState(Issue issue)
+        {
+            return await _stateService.GetState(issue.ProjectId, issue.StateId);
+        }
+    }
+
+    class FsmHandler : IFsmHandler<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>, StateDTO>
+    {
+        private List<FsmEvent<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>>> _events1 = new();
+
+        List<FsmEvent<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>>> IFsmHandler<Func<Issue, StateDTO, StateDTO, Task<StateDTO>>, StateDTO>._events
+        {
+            get => _events1;
+            set => _events1 = value;
+        }
+
+        public async Task<StateDTO> CallAction(Func<Issue, StateDTO, StateDTO, Task<StateDTO>> action, Issue issue, StateDTO oldState, StateDTO newState)
+        {
+            return await action(issue, oldState, newState);
+        }
+    }
+
+    interface IFsmHandler<TFunc, TReturn>
+    {
+        protected List<FsmEvent<TFunc>> _events { get; set; }
+
+        public bool AddEvent(FsmEvent<TFunc> e)
+        {
+            if (Contains(e)) return false;
+            _events.Add(e);
+            return true;
+        }
+
+        public Task<TReturn> CallAction(TFunc action, Issue issue, StateDTO oldState, StateDTO newState);
+
+        public async Task<TReturn> HandleStateUpdate(Issue issue, StateDTO oldState, StateDTO newState)
+        {
+            if (issue == null || oldState == null || newState == null)
+                throw new HttpStatusException(400, "Invalid request, Issue or State does not exist");
+            var e = Find(oldState.Name, newState.Name);
+            if (e == null) throw new HttpStatusException(400, $"cannot update an issue state from {oldState.Name} to {newState.Name}");
+            return await CallAction(e.Func, issue, oldState, newState);
+        }
+
+        private bool Contains(FsmEvent<TFunc> e) => Find(e.OldState, e.NewState) != null;
+
+        private FsmEvent<TFunc>? Find(string oldState, string newState)
+        {
+            var e = new FsmEvent<TFunc>(oldState, newState, default);
+            return _events.FirstOrDefault(it => Equals(it, e));
+        }
+
+        private bool Equals(FsmEvent<TFunc> first, FsmEvent<TFunc> second) =>
+            //((first.OldState == "" || second.OldState == "") || first.OldState == second.OldState) && first.NewState == second.NewState;
+            first.OldState + second.OldState == second.OldState + first.OldState && first.NewState == second.NewState;
+    }
+
+    class FsmEvent<TFunc>
+    {
+        public FsmEvent(string oldState, string newState, TFunc func)
+        {
+            OldState = oldState;
+            NewState = newState;
+            Func = func;
+        }
+
+        public FsmEvent()
+        {
+        }
+
+        public string OldState { get; set; }
+        public string NewState { get; set; }
+        public TFunc Func { get; set; }
+    }
+}

--- a/Goose.API/Services/issues/IssueSummaryService.cs
+++ b/Goose.API/Services/issues/IssueSummaryService.cs
@@ -72,8 +72,9 @@ namespace Goose.API.Services.issues
             if (states is null)
                 throw new HttpStatusException(400, "Es wurden keine Statuse für dieses Project gefunden");
 
-            var state = await _issueStateService.GetNewStateUpdateAssociatedIssues(issue, states.First(it => it.Name == State.ProcessingState));
-
+            var state = await _issueStateService.UpdateState(issue, states.First(it => it.Name == State.ProcessingState));
+            issue = await _issueRepository.GetAsync(issueId.ToObjectId());
+            
             if (state is null)
                 throw new HttpStatusException(400, "Es wurde kein State gefunden");
 

--- a/Goose.API/Startup.cs
+++ b/Goose.API/Startup.cs
@@ -184,6 +184,8 @@ namespace Goose.API
             services.AddScoped<IIssueParentService, IssueParentService>();
             services.AddScoped<IMessageService, MessageService>();
             services.AddScoped<IIssueAssociationHelper, IssueAssociationHelper>();
+            services.AddScoped<IIssueStateService, IssueStateService>();
+            
             services.AddHttpContextAccessor();
         }
 

--- a/Goose.API/Startup.cs
+++ b/Goose.API/Startup.cs
@@ -169,7 +169,7 @@ namespace Goose.API
             services.AddScoped<IIssueRequirementService, IssueRequirementService>();
             services.AddScoped<IIssueRequestValidator, IssueRequestValidator>();
             services.AddScoped<IIssuePredecessorService, IssuePredecessorService>();
-            services.AddScoped<IIssuePredecessorService, IssuePredecessorService>();
+            services.AddScoped<IIssueSuccessorService, IssueSuccessorService>();
             services.AddScoped<IIssueTimeSheetService, IssueTimeSheetService>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IRoleService, RoleService>();

--- a/Goose.API/Utils/ListExtensions.cs
+++ b/Goose.API/Utils/ListExtensions.cs
@@ -79,9 +79,10 @@ namespace Goose.API.Utils
                     return i;
                 }
             }
+
             return -1;
         }
-    
+
         public static IList<T> ConcatOrSkip<T>(this IList<T> list, IList<T> concatee)
         {
             if (list is null)
@@ -90,5 +91,7 @@ namespace Goose.API.Utils
                 return list;
             return list.Concat(concatee).ToList();
         }
+
+        public static bool HasWhere<T>(this IList<T> list, Func<T, bool> fun) => list.FirstOrDefault(fun) != null;
     }
 }

--- a/Goose.Domain/DTOs/StateDTO.cs
+++ b/Goose.Domain/DTOs/StateDTO.cs
@@ -27,5 +27,37 @@ namespace Goose.Domain.DTOs
         public string Name { get; set; }
         public string Phase { get; set; }
         public bool UserGenerated { get; set; }
+
+        public static bool operator <(StateDTO state, StateDTO other)
+        {
+            if (state.Phase == other.Phase) return false;
+            if (state.Phase == State.NegotiationPhase) return true;
+            if (other.Phase == State.NegotiationPhase) return false;
+            if (state.Phase == State.ProcessingPhase) return true;
+            if (other.Phase == State.ProcessingPhase) return false;
+            throw new Exception($"could not compare {state.Phase} and {other.Phase}");
+        }
+
+        public static bool operator >(StateDTO state, StateDTO other)
+        {
+            if (state.Phase == other.Phase) return false;
+            if (state.Phase == State.NegotiationPhase) return false;
+            if (other.Phase == State.NegotiationPhase) return true;
+            if (state.Phase == State.ProcessingPhase) return false;
+            if (other.Phase == State.ProcessingPhase) return true;
+            throw new Exception($"could not compare {state.Phase} and {other.Phase}");
+        }
+
+        public static bool operator >=(StateDTO state, StateDTO other)
+        {
+            if (state.Phase == other.Phase) return true;
+            return state > other;
+        }
+
+        public static bool operator <=(StateDTO state, StateDTO other)
+        {
+            if (state.Phase == other.Phase) return true;
+            return state < other;
+        }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/Issues/IssueStateTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/Issues/IssueStateTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Resources;
+using System.Threading.Tasks;
+using Goose.Domain.DTOs;
+using Goose.Domain.DTOs.Issues;
+using Goose.Domain.Models.Projects;
+using MongoDB.Bson;
+using NUnit.Framework;
+
+namespace Goose.Tests.Application.IntegrationTests.issues
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class IssueStateTests
+    {
+        [Test]
+        public async Task CorrectStateOrderWorks()
+        {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var issue = helper.Issue;
+            var states = await helper.Helper.GetStateListAsync(helper.Issue.Project.Id);
+
+            var updateStates = new List<StateDTO>();
+            updateStates.Add(states.First(it => it.Name == State.NegotiationState));
+            updateStates.Add(states.First(it => it.Name == State.ProcessingState));
+            updateStates.Add(states.First(it => it.Name == State.ReviewState));
+            updateStates.Add(states.First(it => it.Name == State.CompletedState));
+            updateStates.Add(states.First(it => it.Name == State.ArchivedState));
+
+            foreach (var state in updateStates)
+            {
+                issue.State = state;
+                var res = await helper.Helper.UpdateIssue(issue);
+                Assert.AreEqual(HttpStatusCode.NoContent, res.StatusCode);
+            }
+        }
+
+        /*
+         * Fügt n Issues hinzu (anhängig der Anzahl an Statusse die in updateStates sind).
+         * In jeden Schleifendurchlauf wird ein Issue gecancelt, die anderen Issue werden in den nächsten Status gesetzt, die getestet werden sollen
+         */
+        [Test]
+        public async Task CancelIssues()
+        {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var states = await helper.Helper.GetStateListAsync(helper.Issue.Project.Id);
+            var updateStates = new List<StateDTO>();
+            var cancelState = states.First(it => it.Name == State.CancelledState);
+            updateStates.Add(states.First(it => it.Name == State.CheckingState));
+            updateStates.Add(states.First(it => it.Name == State.NegotiationState));
+            updateStates.Add(states.First(it => it.Name == State.ProcessingState));
+            updateStates.Add(states.First(it => it.Name == State.ReviewState));
+
+            var issues = await Task.WhenAll((await Task.WhenAll(updateStates.Select(it => helper.CreateIssue()))).Select(it => it.Parse<IssueDTO>()).ToList());
+            for (int i = 0; i < updateStates.Count; i++)
+            {
+                var state = updateStates[i];
+                issues[i].State = cancelState;
+                for (int j = i; j < updateStates.Count; j++) issues[j].State = state;
+
+                await Task.WhenAll(issues.Skip(i).ToList().Select(it => helper.Helper.UpdateIssue(it)));
+            }
+        }
+
+        [Test]
+        public async Task ChildGetsCancelledOnParentCancel()
+        {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var child = await helper.CreateIssue().Parse<IssueDTO>();
+            await helper.AddIssueChild(child.Id);
+
+            var cancel = await helper.UpdateState(State.CancelledState);
+            Assert.AreEqual(HttpStatusCode.NoContent, cancel.StatusCode);
+            var newChild = await helper.GetIssueAsync(child.Id);
+            Assert.AreEqual((await helper.Helper.GetStateByNameAsync(helper.Project.Id, State.CancelledState)).Id, newChild.StateId);
+        }
+
+        [Test]
+        public async Task SuccessorMovesOutOfBlockedOnPredecessorCancel()
+        {
+        }
+
+        [Test]
+        public async Task SuccessorDoesntMoveOutOfBlockedStateOnPredecessorCancelBecauseHeHasAnotherPredecessor()
+        {
+        }
+    }
+}

--- a/Goose.Tests/Application.IntegrationTests/Issues/IssueSuccessorTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/Issues/IssueSuccessorTests.cs
@@ -1,36 +1,95 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Goose.API.Utils;
+using Goose.Domain.DTOs.Issues;
+using Goose.Domain.Models.Projects;
+using MongoDB.Bson;
 using NUnit.Framework;
 
 namespace Goose.Tests.Application.IntegrationTests.issues
 {
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
     public class IssueSuccessorTests
     {
         [Test]
         public async Task CanAddSuccessor()
         {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var predecessor = await helper.CreateIssue().Parse<IssueDTO>();
+            await helper.SetPredecessor(predecessor.Id);
+
+            var predecessors = helper.Helper.GetPredecessors(helper.Issue.Id);
+            var successors = helper.Helper.GetSuccessors(predecessor.Id);
+
+            Assert.IsTrue((await predecessors.Parse<List<IssueDTO>>()).HasWhere(it => it.Id == predecessor.Id));
+            Assert.IsTrue((await successors.Parse<List<IssueDTO>>()).HasWhere(it => it.Id == helper.Issue.Id));
         }
 
         [Test]
         public async Task IssueHasToWaitUntilPredecessorFinishes()
         {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var predecessor = await helper.CreateIssue().Parse<IssueDTO>();
+            await helper.SetPredecessor(predecessor.Id);
+
+
+            await helper.SetState(State.NegotiationState);
+            await helper.SetState(State.ProcessingState);
+            var newIssue = await helper.GetIssueAsync(helper.Issue.Id);
+            Assert.AreEqual(State.BlockedState, (await helper.Helper.GetStateById(newIssue.ProjectId, newIssue.StateId)).Name);
+
+            await helper.Helper.SetStateOfIssue(predecessor, State.CancelledState);
+            newIssue = await helper.GetIssueAsync(helper.Issue.Id);
+            Assert.AreEqual(State.ProcessingState, (await helper.Helper.GetStateById(newIssue.ProjectId, newIssue.StateId)).Name);
         }
 
         [Test]
-        public async Task CannotSetPredecessorOfAnotherProject()
+        public async Task CannotSetParentAsPredecessor()
         {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var parent = await helper.CreateIssue().Parse<IssueDTO>();
+            await helper.Helper.SetParentIssue(parent.Id, helper.Issue.Id);
+            var res = await helper.SetPredecessor(parent.Id);
+            Assert.AreEqual(HttpStatusCode.BadRequest, res.StatusCode);
         }
 
         [Test]
-        public async Task CannotSetParentAsSuccessor()
+        public async Task CannotSetChildAsPredecessor()
         {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var child = await helper.CreateIssue().Parse<IssueDTO>();
+            await helper.SetIssueChild(child.Id);
+            var res = await helper.Helper.SetPredecessor(helper.Issue.Id, child.Id);
+            Assert.AreEqual(HttpStatusCode.BadRequest, res.StatusCode);
         }
 
         [Test]
-        public async Task CannotSetChildAsSuccessor()
+        public async Task CannotAddPredecessorInConclusionPhase()
         {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var predecessor = await helper.CreateIssue().Parse<IssueDTO>();
+            await helper.Helper.SetStateOfIssue(predecessor, State.NegotiationState);
+            await helper.Helper.SetStateOfIssue(predecessor, State.ProcessingState);
+            await helper.Helper.SetStateOfIssue(predecessor, State.ReviewState);
+            await helper.Helper.SetStateOfIssue(predecessor, State.CompletedState);
+
+            var res = await helper.SetPredecessor(predecessor.Id);
+            Assert.AreEqual(HttpStatusCode.BadRequest, res.StatusCode);
         }
 
-        
-        //TODO cannot add child after specific state
+        [Test]
+        public async Task StartDateOfPredecessorCannotBeAfterEndDateOfSuccessor()
+        {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            var tempPredecessor = helper.Issue.Copy();
+            tempPredecessor.Id = ObjectId.Empty;
+            tempPredecessor.IssueDetail.StartDate = DateTime.Now.AddHours(3);
+            var predecessor = await helper.CreateIssue(tempPredecessor).Parse<IssueDTO>();
+            var res = await helper.SetPredecessor(predecessor.Id);
+            Assert.AreEqual(HttpStatusCode.BadRequest, res.StatusCode);
+        }
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/Issues/IssueSuccessorTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/Issues/IssueSuccessorTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Goose.Tests.Application.IntegrationTests.issues
+{
+    public class IssueSuccessorTests
+    {
+        [Test]
+        public async Task CanAddSuccessor()
+        {
+        }
+
+        [Test]
+        public async Task IssueHasToWaitUntilPredecessorFinishes()
+        {
+        }
+
+        [Test]
+        public async Task CannotSetPredecessorOfAnotherProject()
+        {
+        }
+
+        [Test]
+        public async Task CannotSetParentAsSuccessor()
+        {
+        }
+
+        [Test]
+        public async Task CannotSetChildAsSuccessor()
+        {
+        }
+
+        
+        //TODO cannot add child after specific state
+    }
+}

--- a/Goose.Tests/Application.IntegrationTests/Message/MessageTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/Message/MessageTests.cs
@@ -270,7 +270,9 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             Assert.IsTrue(messageList.Count == 2);
         }
 
-        [Test]
+        //TODO duplicat IssueCanceledMesageTest()?
+       /*
+        *  [Test]
         public async Task IssueCanceledMesageTest2()
         {
             using var helper = await new SimpleTestHelperBuilderMessage().Build();
@@ -293,6 +295,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
 
             Assert.IsTrue(messageList.Count == 0);
         }
+        */
 
         [Test]
         public async Task IssueConversationTest()

--- a/Goose.Tests/Application.IntegrationTests/Message/MessageTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/Message/MessageTests.cs
@@ -270,9 +270,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             Assert.IsTrue(messageList.Count == 2);
         }
 
-        //TODO duplicat IssueCanceledMesageTest()?
-       /*
-        *  [Test]
+        [Test]
         public async Task IssueCanceledMesageTest2()
         {
             using var helper = await new SimpleTestHelperBuilderMessage().Build();
@@ -282,7 +280,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
             var issue = await helper.Helper.GetIssueAsync(helper.Issue.Id);
             var uri = $"/api/projects/{project.Id}/issues/{issue.Id}";
 
-            var newState = await helper.Helper.GetStateByNameAsync(issue.ProjectId, State.BlockedState);
+            var newState = await helper.Helper.GetStateByNameAsync(issue.ProjectId, State.ReviewState);
             var issueDTO = new IssueDTO(issue, newState, project, user, user);
 
             var response = await helper.client.PutAsync(uri, issueDTO.ToStringContent());
@@ -295,7 +293,7 @@ namespace Goose.Tests.Application.IntegrationTests.Message
 
             Assert.IsTrue(messageList.Count == 0);
         }
-        */
+
 
         [Test]
         public async Task IssueConversationTest()

--- a/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
@@ -21,8 +21,6 @@ using MongoDB.Bson;
 
 namespace Goose.Tests.Application.IntegrationTests
 {
-    //TODO wo wird der client header gesetzt
-    //TODO GenerateUserAndSetToProject generiert einen user. Solen seine rollen wirklich als Projekt und CompanyRolle gesetzt werden?
     public class NewTestHelper : IDisposable
     {
         private readonly HttpClient _client;
@@ -294,6 +292,21 @@ namespace Goose.Tests.Application.IntegrationTests
         {
             return (await GetStateListAsync(projectId)).FirstOrDefault(x => x.Id.Equals(Id));
         }
+        public async Task<StateDTO> GetStateById(Issue issue)
+        {
+            return (await GetStateListAsync(issue.ProjectId)).FirstOrDefault(x => x.Id.Equals(issue.StateId));
+        }
+
+        public async Task<HttpResponseMessage> GetPredecessors(ObjectId issueId)
+        {
+            var uri = $"api/issues/{issueId}/predecessors/";
+            return await _client.GetAsync(uri);
+        }
+        public async Task<HttpResponseMessage> GetSuccessors(ObjectId issueId)
+        {
+            var uri = $"api/issues/{issueId}/successors/";
+            return await _client.GetAsync(uri);
+        }
 
         #endregion
 
@@ -302,6 +315,12 @@ namespace Goose.Tests.Application.IntegrationTests
         public async Task<HttpResponseMessage> SetParentIssue(ObjectId parentId, ObjectId childId)
         {
             var uri = $"api/issues/{childId}/parent/{parentId}";
+            return await _client.PutAsync(uri, null);
+        }
+
+        public async Task<HttpResponseMessage> SetPredecessor(ObjectId predecessorId, ObjectId successorId)
+        {
+            var uri = $"api/issues/{successorId}/predecessors/{predecessorId}";
             return await _client.PutAsync(uri, null);
         }
 
@@ -316,7 +335,7 @@ namespace Goose.Tests.Application.IntegrationTests
             return await _client.PutAsync(uri, dto.ToStringContent());
         }
 
-        public async Task<HttpResponseMessage> UpdateStateOfIssue(IssueDTO issue, string stateName)
+        public async Task<HttpResponseMessage> SetStateOfIssue(IssueDTO issue, string stateName)
         {
             var state = await GetStateByNameAsync(issue.Project.Id, stateName);
             var copy = issue.Copy();

--- a/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/NewTestHelper.cs
@@ -83,7 +83,7 @@ namespace Goose.Tests.Application.IntegrationTests
 
         public async Task<HttpResponseMessage> GenerateProject(ObjectId companyId)
         {
-            return await GenerateProject(companyId, new ProjectDTO { Name = $"{new Random().NextDouble()}" });
+            return await GenerateProject(companyId, new ProjectDTO {Name = $"{new Random().NextDouble()}"});
         }
 
         public async Task<HttpResponseMessage> GenerateProject(ObjectId companyId, ProjectDTO projectDto)
@@ -277,7 +277,7 @@ namespace Goose.Tests.Application.IntegrationTests
             return await GetIssueThroughClientAsync(issueDto.Project.Id, issueDto.Id);
         }
 
-        private async Task<IList<StateDTO>> GetStateListAsync(ObjectId projectId)
+        public async Task<IList<StateDTO>> GetStateListAsync(ObjectId projectId)
         {
             var uri = $"api/projects/{projectId}/states";
             var responce = await _client.GetAsync(uri);
@@ -304,10 +304,24 @@ namespace Goose.Tests.Application.IntegrationTests
             var uri = $"api/issues/{childId}/parent/{parentId}";
             return await _client.PutAsync(uri, null);
         }
-        
+
         public void SetAuth(SignInResponse signIn)
         {
             _client.Auth(signIn);
+        }
+
+        public async Task<HttpResponseMessage> UpdateIssue(IssueDTO dto)
+        {
+            var uri = $"api/projects/{dto.Project.Id}/issues/{dto.Id}";
+            return await _client.PutAsync(uri, dto.ToStringContent());
+        }
+
+        public async Task<HttpResponseMessage> UpdateStateOfIssue(IssueDTO issue, string stateName)
+        {
+            var state = await GetStateByNameAsync(issue.Project.Id, stateName);
+            var copy = issue.Copy();
+            copy.State = state;
+            return await UpdateIssue(copy);
         }
 
         #endregion

--- a/Goose.Tests/Application.IntegrationTests/SimpleTestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/SimpleTestHelper.cs
@@ -96,14 +96,19 @@ namespace Goose.Tests.Application.IntegrationTests
             return await Helper.GetIssueAsync(issueId);
         }
 
-        public async Task<HttpResponseMessage> AddIssueChild(ObjectId childId)
+        public async Task<HttpResponseMessage> SetIssueChild(ObjectId childId)
         {
             return await Helper.SetParentIssue(Issue.Id, childId);
         }
 
-        public async Task<HttpResponseMessage> UpdateState(string stateName)
+        public async Task<HttpResponseMessage> SetPredecessor(ObjectId predecessorId)
         {
-            return await Helper.UpdateStateOfIssue(Issue, stateName);
+            return await Helper.SetPredecessor(predecessorId, Issue.Id);
+        }
+
+        public async Task<HttpResponseMessage> SetState(string stateName)
+        {
+            return await Helper.SetStateOfIssue(Issue, stateName);
         }
 
 

--- a/Goose.Tests/Application.IntegrationTests/SimpleTestHelper.cs
+++ b/Goose.Tests/Application.IntegrationTests/SimpleTestHelper.cs
@@ -101,6 +101,11 @@ namespace Goose.Tests.Application.IntegrationTests
             return await Helper.SetParentIssue(Issue.Id, childId);
         }
 
+        public async Task<HttpResponseMessage> UpdateState(string stateName)
+        {
+            return await Helper.UpdateStateOfIssue(Issue, stateName);
+        }
+
 
         public void Dispose()
         {

--- a/Goose.Tests/Application.IntegrationTests/SimpleTestHelperBuilder.cs
+++ b/Goose.Tests/Application.IntegrationTests/SimpleTestHelperBuilder.cs
@@ -37,7 +37,7 @@ namespace Goose.Tests.Application.IntegrationTests
             {
                 Name = $"{new Random().NextDouble()}",
                 Type = Issue.TypeFeature,
-                StartDate = DateTime.Now.AddHours(1),
+                StartDate = null,
                 EndDate = DateTime.Now.AddHours(2),
                 ExpectedTime = 0,
                 Progress = 0,

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
@@ -156,6 +156,8 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
         public async Task SummaryAcceptedConversation()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
+            await helper.UpdateState(State.NegotiationState);
+            
             var issue = helper.Issue;
             IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
             await helper.Helper.IssueRequirementService.CreateAsync(issue.Id, issueRequirement);

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueConversationTests.cs
@@ -156,7 +156,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
         public async Task SummaryAcceptedConversation()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
-            await helper.UpdateState(State.NegotiationState);
+            await helper.SetState(State.NegotiationState);
             
             var issue = helper.Issue;
             IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
@@ -191,7 +191,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             Assert.IsTrue(latestConversationItem is not null);
             Assert.AreEqual(latestConversationItem.CreatorUserId, helper.User.Id);
             Assert.AreEqual(latestConversationItem.Type, IssueConversation.StateChangeType);
-            Assert.AreEqual(latestConversationItem.Data, $"Status von {State.NegotiationState} zu {State.WaitingState} geändert.");
+            Assert.AreEqual(latestConversationItem.Data, $"Status von {State.NegotiationState} zu {State.ProcessingState} geändert.");
         }
 
         [Test]

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueParentTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueParentTests.cs
@@ -82,5 +82,6 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var res = await helper.Helper.SetParentIssue(helper.Issue.Id, issue2.Id);
             Assert.AreEqual(HttpStatusCode.BadRequest, res.StatusCode);
         }
+        //TODO cannot add child after specific state
     }
 }

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueRequirementTests.cs
@@ -87,11 +87,8 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
         public async Task AddRequirementInProcessingPhaseFalse()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
-
-            var issue = helper.Issue.Copy();
-            issue.State = await helper.Helper.GetStateByNameAsync(helper.Project.Id, State.ProcessingState);
-            var uri = $"api/projects/{issue.Project.Id}/issues/{issue.Id}";
-            var response = await helper.client.PutAsync(uri, issue.ToStringContent());
+            await helper.SetState(State.NegotiationState);
+            await helper.SetState(State.ProcessingState);
 
             var res = await helper.Helper.GenerateRequirement();
             Assert.True(ObjectId.Empty.Equals(res.Id));
@@ -101,11 +98,10 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
         public async Task AddRequirementInConclusionPhaseFalse()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
-
-            var issue = helper.Issue.Copy();
-            issue.State = await helper.Helper.GetStateByNameAsync(helper.Project.Id, State.CompletedState);
-            var uri = $"api/projects/{issue.Project.Id}/issues/{issue.Id}";
-            var response = await helper.client.PutAsync(uri, issue.ToStringContent());
+            await helper.SetState(State.NegotiationState);
+            await helper.SetState(State.ProcessingState);
+            await helper.SetState(State.ReviewState);
+            await helper.SetState(State.CompletedState);
 
             var res = await helper.Helper.GenerateRequirement();
             Assert.True(ObjectId.Empty.Equals(res.Id));

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueRightTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueRightTests.cs
@@ -128,7 +128,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             await helper.Helper.GenerateUserAndSetToProject(helper.Company.Id, helper.Project.Id, Role.EmployeeRole);
 
             var copy = helper.Issue.Copy();
-            copy.State = await helper.Helper.GetStateByNameAsync(copy.Project.Id, State.WaitingState);
+            copy.State = await helper.Helper.GetStateByNameAsync(copy.Project.Id, State.NegotiationState);
 
             var uri = $"api/projects/{copy.Project.Id}/issues/{copy.Id}";
 

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryRightTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryRightTests.cs
@@ -128,8 +128,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             var newIssue = await helper.GetIssueAsync(issue.Id);
             Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
 
-            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.ProcessingState);
-            Assert.AreEqual(state.Id, newIssue.StateId);
+            Assert.AreEqual(State.ProcessingState, (await helper.Helper.GetStateById(newIssue)).Name);
 
             issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };
             uri = $"/api/issues/{issue.Id}/requirements/";
@@ -187,8 +186,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             var newIssue = await helper.GetIssueAsync(issue.Id);
             Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
 
-            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.ProcessingState);
-            Assert.AreEqual(state.Id, newIssue.StateId);
+            Assert.AreEqual(State.ProcessingState, (await helper.Helper.GetStateById(newIssue)).Name);
 
             issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };
             uri = $"/api/issues/{issue.Id}/requirements/";
@@ -219,8 +217,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             var newIssue = await helper.GetIssueAsync(issue.Id);
             Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
 
-            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.ProcessingState);
-            Assert.AreEqual(state.Id, newIssue.StateId);
+            Assert.AreEqual(State.ProcessingState, (await helper.Helper.GetStateById(newIssue)).Name);
 
             issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };
             uri = $"/api/issues/{issue.Id}/requirements/";

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryRightTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryRightTests.cs
@@ -103,7 +103,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         {
             var builder = new SimpleTestHelperBuilderSummaryRights(Role.CustomerRole);
             using var helper = await builder.Build();
-            await helper.UpdateState(State.NegotiationState);
+            await helper.SetState(State.NegotiationState);
 
             var issue = helper.Issue;
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
@@ -128,7 +128,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var newIssue = await helper.GetIssueAsync(issue.Id);
             Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
 
-            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.WaitingState);
+            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.ProcessingState);
             Assert.AreEqual(state.Id, newIssue.StateId);
 
             issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };
@@ -162,7 +162,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         {
             var builder = new SimpleTestHelperBuilderSummaryRights(Role.EmployeeRole);
             using var helper = await builder.Build();
-            await helper.UpdateState(State.NegotiationState);
+            await helper.SetState(State.NegotiationState);
             
             var issue = helper.Issue;
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
@@ -187,7 +187,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var newIssue = await helper.GetIssueAsync(issue.Id);
             Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
 
-            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.WaitingState);
+            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.ProcessingState);
             Assert.AreEqual(state.Id, newIssue.StateId);
 
             issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };
@@ -202,7 +202,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         {
             var builder = new SimpleTestHelperBuilderSummaryRights(Role.EmployeeRole);
             using var helper = await builder.Build();
-            await helper.UpdateState(State.NegotiationState);
+            await helper.SetState(State.NegotiationState);
 
             var issue = helper.Issue;
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
@@ -219,7 +219,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
             var newIssue = await helper.GetIssueAsync(issue.Id);
             Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
 
-            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.WaitingState);
+            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.ProcessingState);
             Assert.AreEqual(state.Id, newIssue.StateId);
 
             issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryRightTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryRightTests.cs
@@ -103,6 +103,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         {
             var builder = new SimpleTestHelperBuilderSummaryRights(Role.CustomerRole);
             using var helper = await builder.Build();
+            await helper.UpdateState(State.NegotiationState);
 
             var issue = helper.Issue;
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
@@ -161,7 +162,8 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         {
             var builder = new SimpleTestHelperBuilderSummaryRights(Role.EmployeeRole);
             using var helper = await builder.Build();
-
+            await helper.UpdateState(State.NegotiationState);
+            
             var issue = helper.Issue;
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
             await helper.Helper.IssueRequirementService.CreateAsync(issue.Id, issueRequirement);
@@ -200,6 +202,7 @@ namespace Goose.Tests.Application.IntegrationTests.issues
         {
             var builder = new SimpleTestHelperBuilderSummaryRights(Role.EmployeeRole);
             using var helper = await builder.Build();
+            await helper.UpdateState(State.NegotiationState);
 
             var issue = helper.Issue;
             IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
@@ -62,7 +62,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
         public async Task AcceptSummary()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
-            await helper.UpdateState(State.NegotiationState);
+            await helper.SetState(State.NegotiationState);
 
             var issue = helper.Issue;
             IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
@@ -79,7 +79,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             var newIssue = await helper.GetIssueAsync(issue.Id);
             Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
 
-            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.WaitingState);
+            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.ProcessingState);
             Assert.AreEqual(state.Id, newIssue.StateId);
 
             issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen2"};
@@ -143,7 +143,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
         public async Task DeclineSummaryFalse2()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
-            await helper.UpdateState(State.NegotiationState);
+            await helper.SetState(State.NegotiationState);
             
             IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
             await helper.Helper.IssueRequirementService.CreateAsync(helper.Issue.Id, issueRequirement);
@@ -160,7 +160,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             Assert.IsTrue(issue.IssueDetail.RequirementsAccepted);
 
 
-            var state = await helper.Helper.GetStateByNameAsync(issue.ProjectId, State.WaitingState);
+            var state = await helper.Helper.GetStateByNameAsync(issue.ProjectId, State.ProcessingState);
             Assert.AreEqual(state.Id, issue.StateId);
 
             uri = $"/api/issues/{issue.Id}/summaries?accept=false";

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
@@ -79,8 +79,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             var newIssue = await helper.GetIssueAsync(issue.Id);
             Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
 
-            var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.ProcessingState);
-            Assert.AreEqual(state.Id, newIssue.StateId);
+            Assert.AreEqual(State.ProcessingState, (await helper.Helper.GetStateById(newIssue)).Name);
 
             issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen2"};
             uri = $"/api/issues/{issue.Id}/requirements/";
@@ -160,8 +159,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             Assert.IsTrue(issue.IssueDetail.RequirementsAccepted);
 
 
-            var state = await helper.Helper.GetStateByNameAsync(issue.ProjectId, State.ProcessingState);
-            Assert.AreEqual(state.Id, issue.StateId);
+            Assert.AreEqual(State.ProcessingState, (await helper.Helper.GetStateById(issue)).Name);
 
             uri = $"/api/issues/{issue.Id}/summaries?accept=false";
             responce = await helper.client.PutAsync(uri, new object().ToStringContent());

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
@@ -21,7 +21,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             using var helper = await new SimpleTestHelperBuilder().Build();
 
             var issue = helper.Issue;
-            IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
+            IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
             await helper.Helper.IssueRequirementService.CreateAsync(issue.Id, issueRequirement);
 
             var uri = $"/api/issues/{issue.Id}/summaries";
@@ -36,11 +36,10 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
 
             Assert.IsTrue(requirements != null && requirements.Count > 0);
 
-            issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };
+            issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen2"};
             uri = $"/api/issues/{issue.Id}/requirements/";
             response = await helper.client.PostAsync(uri, issueRequirement.ToStringContent());
             Assert.IsFalse(response.IsSuccessStatusCode);
-
         }
 
         [Test]
@@ -57,16 +56,16 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             uri = $"/api/issues/{issue.Id}/summaries";
             responce = await helper.client.GetAsync(uri);
             Assert.IsFalse(responce.IsSuccessStatusCode);
-
         }
 
         [Test]
         public async Task AcceptSummary()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
+            await helper.UpdateState(State.NegotiationState);
 
             var issue = helper.Issue;
-            IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
+            IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
             await helper.Helper.IssueRequirementService.CreateAsync(issue.Id, issueRequirement);
 
             var uri = $"/api/issues/{issue.Id}/summaries";
@@ -83,11 +82,10 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             var state = await helper.Helper.GetStateByNameAsync(newIssue.ProjectId, State.WaitingState);
             Assert.AreEqual(state.Id, newIssue.StateId);
 
-            issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };
+            issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen2"};
             uri = $"/api/issues/{issue.Id}/requirements/";
             response = await helper.client.PostAsync(uri, issueRequirement.ToStringContent());
             Assert.IsFalse(response.IsSuccessStatusCode);
-
         }
 
         [Test]
@@ -98,7 +96,6 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             var uri = $"/api/issues/{helper.Issue.Id}/summaries?accept=true";
             var response = await helper.client.PutAsync(uri, new object().ToStringContent());
             Assert.IsFalse(response.IsSuccessStatusCode);
-
         }
 
         [Test]
@@ -106,7 +103,7 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
 
-            IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
+            IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
             await helper.Helper.IssueRequirementService.CreateAsync(helper.Issue.Id, issueRequirement);
 
             var uri = $"/api/issues/{helper.Issue.Id}/summaries";
@@ -121,11 +118,10 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             Assert.IsFalse(issue.IssueDetail.RequirementsAccepted);
             Assert.IsFalse(issue.IssueDetail.RequirementsSummaryCreated);
 
-            issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };
+            issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen2"};
             uri = $"/api/issues/{issue.Id}/requirements/";
             responce = await helper.client.PostAsync(uri, issueRequirement.ToStringContent());
             Assert.IsTrue(responce.IsSuccessStatusCode);
-
         }
 
         [Test]
@@ -137,19 +133,19 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             var responce = await helper.client.PutAsync(uri, new object().ToStringContent());
             Assert.IsFalse(responce.IsSuccessStatusCode);
 
-            var issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen2" };
+            var issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen2"};
             uri = $"/api/issues/{helper.Issue.Id}/requirements/";
             responce = await helper.client.PostAsync(uri, issueRequirement.ToStringContent());
             Assert.IsTrue(responce.IsSuccessStatusCode);
-
         }
 
         [Test]
         public async Task DeclineSummaryFalse2()
         {
             using var helper = await new SimpleTestHelperBuilder().Build();
-
-            IssueRequirement issueRequirement = new IssueRequirement() { Requirement = "Die Application Testen" };
+            await helper.UpdateState(State.NegotiationState);
+            
+            IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
             await helper.Helper.IssueRequirementService.CreateAsync(helper.Issue.Id, issueRequirement);
 
             var uri = $"/api/issues/{helper.Issue.Id}/summaries";
@@ -170,7 +166,6 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             uri = $"/api/issues/{issue.Id}/summaries?accept=false";
             responce = await helper.client.PutAsync(uri, new object().ToStringContent());
             Assert.IsFalse(responce.IsSuccessStatusCode);
-
         }
     }
 }


### PR DESCRIPTION
Der PR beinhaltet folgende Requirements.
T95: Ein Ticket kann ein oder mehrere Vorgänger hinzugefügt/entfernt werden
T97: Wenn es einen Vorgänger gibt wird Ticket blockiert bis der Vorgänger in Abschlussphase ist
T85: Status "Review" kann nur betreten werden wenn alle Untertickets abgeschlossen sind
T80: Wenn Status "Abgebrochen" erreicht wird Status von allen Untertickets zu abgebrochen geändert
- Nachfolger werden automatisch aus BlockedState in ProceddingState gebracht wenn der Vorgänger abgebrochen wird.
- Statusänderungen werden strenger überwacht (Siehe Statusdiagramm)

Der IssueStateService kümmert sich um Stateänderungen eines Issues und aktualisiert auch automatisch den Status von assoziierten Issues.

Mir ist wieder aufgefallen, dass noch ein paar Details fehlen (z.B. das Beachten von Startdatum/Enddatum). Der PR ist also nicht final. Außerdem wird noch ein commit folgen in dem ich die fehlenden Tests nachliefere.
