### PR TITLE
Feature/bug fixes2

### DIFF
--- a/Goose.API/Services/issues/IssueService.cs
+++ b/Goose.API/Services/issues/IssueService.cs
@@ -114,7 +114,12 @@ namespace Goose.API.Services.Issues
         private async Task<Issue> CreateValidIssue(IssueDTO dto)
         {
             if (dto.IssueDetail.RequirementsNeeded) dto.State = await GetState(dto.Project.Id, State.CheckingState);
-            else dto.State = await GetState(dto.Project.Id, State.ProcessingState);
+            else
+            {
+                if (dto.IssueDetail.StartDate > DateTime.Now) dto.State = await GetState(dto.Project.Id, State.WaitingState);
+                else dto.State = await GetState(dto.Project.Id, State.ProcessingState);
+            }
+
             var issue = new Issue
             {
                 Id = dto.Id,

--- a/Goose.API/Services/issues/IssueStateService.cs
+++ b/Goose.API/Services/issues/IssueStateService.cs
@@ -53,7 +53,7 @@ namespace Goose.API.Services.issues
 
 
                 Task<StateDTO> parentState = null;
-                if (parent is { } parentNotNull) parentState = _stateService.GetState((await parentNotNull).ProjectId, (await parentNotNull).Id);
+                if (parent is { } parentNotNull) parentState = _stateService.GetState((await parentNotNull).ProjectId, (await parentNotNull).StateId);
                 var predecessorStates = await Task.WhenAll((await predecessors).Select(it => _stateService.GetState(it.ProjectId, it.StateId)));
 
                 /*
@@ -62,14 +62,18 @@ namespace Goose.API.Services.issues
                  * 2) Nicht alle Vorgänger abgeschlossen sind
                  * 
                  */
-                if (parentState != null && (await parentState).Phase == State.NegotiationPhase ||
+                if (parentState != null && ((await parentState).Phase == State.NegotiationPhase ||
+                                            (await parentState).Phase == State.BlockedState ||
+                                            (await parentState).Phase == State.WaitingState) ||
                     predecessorStates.HasWhere(it => it.Phase != State.ConclusionPhase))
                 {
                     var blockedState = await GetStateByName(issue, State.BlockedState);
                     return await SetState(issue, blockedState);
                 }
 
-                return await SetState(issue, newState);
+                var res = await SetState(issue, newState);
+                await OnIssueReachedProcessingPhase(issue);
+                return res;
             };
 
             _updateStateHandler.AddEvent(
@@ -159,6 +163,24 @@ namespace Goose.API.Services.issues
             _updateStateHandler.AddUserGeneratedStateCase(State.NegotiationPhase, State.NegotiationState);
             _updateStateHandler.AddUserGeneratedStateCase(State.ProcessingPhase, State.ProcessingState);
             _updateStateHandler.AddUserGeneratedStateCase(State.ConclusionPhase, State.CompletedState);
+        }
+
+        private async Task OnIssueReachedProcessingPhase(Issue issue)
+        {
+            var children = await Task.WhenAll(issue.ChildrenIssueIds.Select(_issueRepository.GetAsync));
+
+            try
+            {
+                var processingState = await GetStateByName(issue, State.ProcessingState);
+                var blockedState = await GetStateByName(issue, State.BlockedState);
+                var blockedChildren = children.Where(it => it.StateId == blockedState.Id).ToList();
+
+                await Task.WhenAll(blockedChildren.Select(it => TryCatch(UpdateState(it, processingState))));
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
         }
 
         private async Task OnIssueReachedCompletionPhase(Issue issue, Issue? _parent = null, IList<Issue>? _successors = null)

--- a/Goose.API/Services/issues/IssueSummaryService.cs
+++ b/Goose.API/Services/issues/IssueSummaryService.cs
@@ -100,7 +100,7 @@ namespace Goose.API.Services.issues
                 StateChange = new()
                 {
                     Before = State.NegotiationState,
-                    After = State.WaitingState
+                    After = state.Name
                 }
             });
             await _issueRepository.UpdateAsync(issue);

--- a/Goose.API/Services/issues/IssueSummaryService.cs
+++ b/Goose.API/Services/issues/IssueSummaryService.cs
@@ -72,9 +72,11 @@ namespace Goose.API.Services.issues
             if (states is null)
                 throw new HttpStatusException(400, "Es wurden keine Statuse für dieses Project gefunden");
 
+            var oldState = states.First(it => it.Id == issue.StateId);
+            if (oldState.Name == State.CheckingState) await _issueStateService.UpdateState(issue, states.First(it => it.Name == State.NegotiationState));
             var state = await _issueStateService.UpdateState(issue, states.First(it => it.Name == State.ProcessingState));
             issue = await _issueRepository.GetAsync(issueId.ToObjectId());
-            
+
             if (state is null)
                 throw new HttpStatusException(400, "Es wurde kein State gefunden");
 
@@ -99,7 +101,7 @@ namespace Goose.API.Services.issues
                 Data = $"Status von {State.NegotiationState} zu {state.Name} geändert.",
                 StateChange = new()
                 {
-                    Before = State.NegotiationState,
+                    Before = oldState.Name,
                     After = state.Name
                 }
             });

--- a/Goose.Tests/Application.IntegrationTests/Issues/IssueTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/Issues/IssueTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Goose.Domain.DTOs.Issues;
+using Goose.Domain.Models.Issues;
+using Goose.Domain.Models.Projects;
+using NUnit.Framework;
+
+namespace Goose.Tests.Application.IntegrationTests.issues
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class IssueTests
+    {
+        private class SimpleTestHelperBuilderStartDate : SimpleTestHelperBuilder
+        {
+            public override IssueDTO GetIssueDTOCopy(HttpClient client, SimpleTestHelper helper)
+            {
+                IssueDTO issueCopy = base.GetIssueDTOCopy(client, helper);
+                issueCopy.IssueDetail.RequirementsNeeded = false;
+                issueCopy.IssueDetail.StartDate = DateTime.Now.AddSeconds(300);
+                return issueCopy;
+            }
+        }
+        
+        [Test]
+        public async Task BugIssueStartsInWaitingStateIfStartDateNotReached()
+        {
+            var helper = await new SimpleTestHelperBuilderStartDate().Build();
+            Assert.AreEqual(State.WaitingState, helper.Issue.State.Name);
+        }
+    }
+}

--- a/Goose.Tests/Application.IntegrationTests/TestUtil.cs
+++ b/Goose.Tests/Application.IntegrationTests/TestUtil.cs
@@ -23,7 +23,7 @@ namespace Goose.Tests.Application.IntegrationTests
 
         public static async Task<E> Parse<E>(this Task<HttpResponseMessage> message)
         {
-            return await (await message).Content.Parse<E>();
+            return await (await message).Parse<E>();
         }
 
         public static async Task<E> Parse<E>(this HttpResponseMessage message)

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
@@ -86,6 +86,33 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             response = await helper.client.PostAsync(uri, issueRequirement.ToStringContent());
             Assert.IsFalse(response.IsSuccessStatusCode);
         }
+        [Test]
+        public async Task AcceptSummaryInCheckingState()
+        {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+
+            var issue = helper.Issue;
+            IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
+            await helper.Helper.IssueRequirementService.CreateAsync(issue.Id, issueRequirement);
+
+            var uri = $"/api/issues/{issue.Id}/summaries";
+            var response = await helper.client.PostAsync(uri, 1.0.ToStringContent());
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            uri = $"/api/issues/{issue.Id}/summaries?accept=true";
+            response = await helper.client.PutAsync(uri, 1.0.ToStringContent());
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            var newIssue = await helper.GetIssueAsync(issue.Id);
+            Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
+
+            Assert.AreEqual(State.ProcessingState, (await helper.Helper.GetStateById(newIssue)).Name);
+
+            issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen2"};
+            uri = $"/api/issues/{issue.Id}/requirements/";
+            response = await helper.client.PostAsync(uri, issueRequirement.ToStringContent());
+            Assert.IsFalse(response.IsSuccessStatusCode);
+        }
 
         [Test]
         public async Task AcceptSummaryFalse()

--- a/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
+++ b/Goose.Tests/Application.IntegrationTests/issues/IssueSummaryTests.cs
@@ -192,5 +192,35 @@ namespace Goose.Tests.Application.IntegrationTests.Issues
             responce = await helper.client.PutAsync(uri, 1.0.ToStringContent());
             Assert.IsFalse(responce.IsSuccessStatusCode);
         }
+        
+        [Test]
+        public async Task AcceptSummaryOfChild()
+        {
+            using var helper = await new SimpleTestHelperBuilder().Build();
+            await helper.SetState(State.NegotiationState);
+            await helper.SetState(State.ProcessingState);
+
+            var issue = await helper.CreateChild();
+            IssueRequirement issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen"};
+            await helper.Helper.IssueRequirementService.CreateAsync(issue.Id, issueRequirement);
+
+            var uri = $"/api/issues/{issue.Id}/summaries";
+            var response = await helper.client.PostAsync(uri, 1.0.ToStringContent());
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            uri = $"/api/issues/{issue.Id}/summaries?accept=true";
+            response = await helper.client.PutAsync(uri, 1.0.ToStringContent());
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            var newIssue = await helper.GetIssueAsync(issue.Id);
+            Assert.IsTrue(newIssue.IssueDetail.RequirementsAccepted);
+
+            Assert.AreEqual(State.ProcessingState, (await helper.Helper.GetStateById(newIssue)).Name);
+
+            issueRequirement = new IssueRequirement() {Requirement = "Die Application Testen2"};
+            uri = $"/api/issues/{issue.Id}/requirements/";
+            response = await helper.client.PostAsync(uri, issueRequirement.ToStringContent());
+            Assert.IsFalse(response.IsSuccessStatusCode);
+        }
     }
 }


### PR DESCRIPTION
Folgendes wurde gefixt:
- #127 Unterticket nicht in "Wartend" wenn mit Startdatum als "Fehler" gestartet wird 
- #122 M43.5:
Wenn ein Unterticket in die Bearbeitungsphase kommt während das Oberticket noch nicht gestartet hat (Startdatum, Verhandlungsphase, Vorgänger), blockiert oder wartet es
- #129 Ticket soll auch akzeptiert werden können, auch wenn Issue noch in Überprüfung ist

@gedankenessen/backend 